### PR TITLE
Add manager dropdown selection

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -29,6 +29,8 @@ def home(request):
 # ---------------------------------------------------------------------------
 def register(request):
     """تسجيل متدرّب جديد ثم إرسال رابط التفعيل إلى بريده الإلكتروني."""
+    managers = User.objects.all()
+
     if request.method == "POST":
         data = request.POST
         errors = []
@@ -67,7 +69,7 @@ def register(request):
         if errors:
             for err in errors:
                 messages.error(request, err)
-            return render(request, "core/register.html", status=200)
+            return render(request, "core/register.html", {"managers": managers}, status=200)
 
         # ---------------------------------------------------------------------
         # إنشاء المستخدم (مُعطَّل لحين التفعيل)
@@ -144,7 +146,7 @@ def register(request):
         return redirect("core:register_thanks")
 
     # GET
-    return render(request, "core/register.html")
+    return render(request, "core/register.html", {"managers": managers})
 
 
 # ---------------------------------------------------------------------------

--- a/templates/core/register.html
+++ b/templates/core/register.html
@@ -107,9 +107,14 @@
           </div>
           <div>
             <label class="block mb-1 text-sm font-semibold">المدير المباشر</label>
-            <input type="text" name="manager" placeholder="محمد السالم"
-                   class="w-full border-2 border-gray-300 rounded-lg px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-300 placeholder-gray-500 transition"
-                   required>
+            <select name="manager"
+                    class="w-full border-2 border-gray-300 rounded-lg px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-300 text-gray-700 transition"
+                    required>
+              <option value="">اختر المدير</option>
+              {% for m in managers %}
+              <option value="{{ m.id }}">{{ m.get_full_name|default:m.username }}</option>
+              {% endfor %}
+            </select>
           </div>
         </div>
         <div class="mt-10 flex justify-between">


### PR DESCRIPTION
## Summary
- show managers in a select list during registration
- pass manager list from register view

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6850770f35088332be693f3f0d1881ce