### PR TITLE
Make manager field text

### DIFF
--- a/core/migrations/0006_manager_charfield.py
+++ b/core/migrations/0006_manager_charfield.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0005_alter_learner_options_alter_section_options'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='learner',
+            name='manager',
+            field=models.CharField(
+                max_length=50,
+                verbose_name='المدير المباشر',
+                null=True,
+                blank=True,
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -73,13 +73,11 @@ class Learner(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
     )
-    manager = models.ForeignKey(
-        User,
-        on_delete=models.SET_NULL,
+    manager = models.CharField(
+        "المدير المباشر",
+        max_length=50,
         null=True,
         blank=True,
-        related_name="managed_learners",
-        verbose_name="المدير المباشر",
     )
 
     # --- الخطوة 3: معلومات التواصل ---

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from django.db import IntegrityError
-from django.contrib.auth.models import User
 
 from .models import (
     Learner,
@@ -20,7 +19,6 @@ class LearnerModelTest(TestCase):
         self.section = Section.objects.create(name="القسم", department=self.department)
         self.nationality = Nationality.objects.create(name="سعودي")
         self.sector = Sector.objects.create(name="القطاع")
-        self.manager = User.objects.create(username="manager")
 
     # دالة مساعدة لإنشاء متدرّب مع إمكانية تجاوز القيم الافتراضية
     def _create_learner(self, **kwargs):
@@ -33,7 +31,7 @@ class LearnerModelTest(TestCase):
             "section": self.section,
             "nationality": self.nationality,
             "sector": self.sector,
-            "manager": self.manager,
+            "manager": "مدير",
             "email": "unique@example.com",
             "national_id": "1234567890",
             "employee_number": "emp1",
@@ -75,10 +73,10 @@ class LearnerModelTest(TestCase):
 
     # ----------------- اختبارات العلاقات -----------------
 
-    def test_manager_is_user_instance(self):
-        """يجب أن يشير حقل المدير إلى كائن مستخدم فعلي."""
-        learner = self._create_learner()
-        self.assertEqual(learner.manager, self.manager)
+    def test_manager_saved_as_text(self):
+        """يجب حفظ اسم المدير كنص عادي."""
+        learner = self._create_learner(manager="مدير تنفيذي")
+        self.assertEqual(learner.manager, "مدير تنفيذي")
 
     def test_nationality_and_sector_relations(self):
         """يجب ربط الجنسية والقطاع بالكيانات المرجعية الصحيحة."""

--- a/core/views.py
+++ b/core/views.py
@@ -29,7 +29,6 @@ def home(request):
 # ---------------------------------------------------------------------------
 def register(request):
     """تسجيل متدرّب جديد ثم إرسال رابط التفعيل إلى بريده الإلكتروني."""
-    managers = User.objects.all()
 
     if request.method == "POST":
         data = request.POST
@@ -69,7 +68,7 @@ def register(request):
         if errors:
             for err in errors:
                 messages.error(request, err)
-            return render(request, "core/register.html", {"managers": managers}, status=200)
+            return render(request, "core/register.html", status=200)
 
         # ---------------------------------------------------------------------
         # إنشاء المستخدم (مُعطَّل لحين التفعيل)
@@ -98,14 +97,7 @@ def register(request):
         if sectr_name:
             sector, _ = Sector.objects.get_or_create(name=sectr_name)
 
-        manager = None
-        manager_id = data.get("manager")
-        if manager_id:
-            try:
-                manager = User.objects.get(pk=manager_id)
-            except (User.DoesNotExist, ValueError):
-                messages.error(request, "المدير المباشر غير موجود")
-                manager = None
+        manager_name = data.get("manager", "").strip()
 
         # إنشاء سجل المتدرّب مع العلاقات المرجعية
         Learner.objects.create(
@@ -116,7 +108,7 @@ def register(request):
             employee_number=data["employee_number"],
             department=department,
             section=section,
-            manager=manager,
+            manager=manager_name,
             email=data["email"],
             mobile=data.get("mobile", ""),
             national_id=data.get("national_id", ""),
@@ -146,7 +138,7 @@ def register(request):
         return redirect("core:register_thanks")
 
     # GET
-    return render(request, "core/register.html", {"managers": managers})
+    return render(request, "core/register.html")
 
 
 # ---------------------------------------------------------------------------

--- a/templates/core/register.html
+++ b/templates/core/register.html
@@ -107,14 +107,9 @@
           </div>
           <div>
             <label class="block mb-1 text-sm font-semibold">المدير المباشر</label>
-            <select name="manager"
-                    class="w-full border-2 border-gray-300 rounded-lg px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-300 text-gray-700 transition"
-                    required>
-              <option value="">اختر المدير</option>
-              {% for m in managers %}
-              <option value="{{ m.id }}">{{ m.get_full_name|default:m.username }}</option>
-              {% endfor %}
-            </select>
+            <input type="text" name="manager" placeholder="اسم المدير"
+                   class="w-full border-2 border-gray-300 rounded-lg px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-300 placeholder-gray-500 transition"
+                   required>
           </div>
         </div>
         <div class="mt-10 flex justify-between">


### PR DESCRIPTION
## Summary
- change `manager` from a ForeignKey to a simple text field
- add migration for the manager change
- accept text value in the registration view
- update registration template to use a text input
- adjust tests for the text manager field

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685079dba508833295215558b93fc1c4