### PR TITLE
Switch department and section to text

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -2,7 +2,7 @@
 from django import forms
 from django.contrib.auth.models import User
 
-from .models import Learner, Department, Section, Nationality, Sector
+from .models import Learner, Nationality, Sector
 
 
 # ـــــــ الخطوة 1: المعلومات الشخصية ـــــــ #

--- a/core/migrations/0007_department_section_charfields.py
+++ b/core/migrations/0007_department_section_charfields.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0006_manager_charfield"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="learner",
+            name="department",
+            field=models.CharField(
+                max_length=50,
+                verbose_name="الإدارة",
+                null=True,
+                blank=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="learner",
+            name="section",
+            field=models.CharField(
+                max_length=50,
+                verbose_name="القسم",
+                null=True,
+                blank=True,
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -59,19 +59,17 @@ class Learner(models.Model):
         blank=True,
         db_index=True,
     )
-    department = models.ForeignKey(
-        Department,
-        verbose_name="الإدارة",
+    department = models.CharField(
+        "الإدارة",
+        max_length=50,
         null=True,
         blank=True,
-        on_delete=models.SET_NULL,
     )
-    section = models.ForeignKey(
-        Section,
-        verbose_name="القسم",
+    section = models.CharField(
+        "القسم",
+        max_length=50,
         null=True,
         blank=True,
-        on_delete=models.SET_NULL,
     )
     manager = models.CharField(
         "المدير المباشر",

--- a/core/tests.py
+++ b/core/tests.py
@@ -3,8 +3,6 @@ from django.db import IntegrityError
 
 from .models import (
     Learner,
-    Department,
-    Section,
     Nationality,
     Sector,
 )
@@ -15,8 +13,8 @@ class LearnerModelTest(TestCase):
 
     def setUp(self):
         # كيانات مرجعية أساسية يستخدمها كل اختبار
-        self.department = Department.objects.create(name="الإدارة")
-        self.section = Section.objects.create(name="القسم", department=self.department)
+        self.department = "الإدارة"
+        self.section = "القسم"
         self.nationality = Nationality.objects.create(name="سعودي")
         self.sector = Sector.objects.create(name="القطاع")
 

--- a/core/views.py
+++ b/core/views.py
@@ -12,7 +12,7 @@ from django.core.mail import send_mail
 from django.contrib.sites.shortcuts import get_current_site
 import re
 
-from .models import Learner, Department, Section, Nationality, Sector
+from .models import Learner, Nationality, Sector
 
 
 # ---------------------------------------------------------------------------
@@ -79,17 +79,14 @@ def register(request):
             is_active=False,
         )
 
-        # ----- حل الكيانات المرجعية بالأسماء --------------------------------
+        # ----- حقل الإدارة والقسم نصياً --------------------------------------
         dept_name = data.get("department", "").strip()
         sect_name = data.get("section", "").strip()
         nat_name  = data.get("nationality", "").strip()
         sectr_name= data.get("sector", "").strip()
 
-        department, _ = Department.objects.get_or_create(name=dept_name)
-        section, _ = Section.objects.get_or_create(
-            name=sect_name,
-            department=department,
-        )
+        department = dept_name or None
+        section    = sect_name or None
         nationality = None
         if nat_name:
             nationality, _ = Nationality.objects.get_or_create(name=nat_name)


### PR DESCRIPTION
## Summary
- change `Learner.department` and `Learner.section` to `CharField`
- update registration logic to store department/section as plain text
- remove unused imports
- add migration for the field changes
- adjust tests to use simple string values

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68519fb8c9188332aa1cd7683169c6b1