### PR TITLE
Fix migration for department/section foreign keys

### DIFF
--- a/core/migrations/0008_department_section_foreignkeys.py
+++ b/core/migrations/0008_department_section_foreignkeys.py
@@ -1,15 +1,40 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
+
+def copy_names_to_fk(apps, schema_editor):
+    Learner = apps.get_model("core", "Learner")
+    Department = apps.get_model("core", "Department")
+    Section = apps.get_model("core", "Section")
+
+    for learner in Learner.objects.all():
+        dept_name = getattr(learner, "department")
+        sect_name = getattr(learner, "section")
+
+        department = None
+        if dept_name:
+            department, _ = Department.objects.get_or_create(name=dept_name)
+
+        section = None
+        if sect_name and department:
+            section, _ = Section.objects.get_or_create(
+                name=sect_name,
+                department=department,
+            )
+
+        learner.department_tmp = department
+        learner.section_tmp = section
+        learner.save(update_fields=["department_tmp", "section_tmp"])
+
 class Migration(migrations.Migration):
     dependencies = [
         ('core', '0007_department_section_charfields'),
     ]
 
     operations = [
-        migrations.AlterField(
+        migrations.AddField(
             model_name='learner',
-            name='department',
+            name='department_tmp',
             field=models.ForeignKey(
                 to='core.department',
                 on_delete=django.db.models.deletion.SET_NULL,
@@ -18,9 +43,9 @@ class Migration(migrations.Migration):
                 verbose_name='الإدارة',
             ),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='learner',
-            name='section',
+            name='section_tmp',
             field=models.ForeignKey(
                 to='core.section',
                 on_delete=django.db.models.deletion.SET_NULL,
@@ -28,5 +53,24 @@ class Migration(migrations.Migration):
                 blank=True,
                 verbose_name='القسم',
             ),
+        ),
+        migrations.RunPython(copy_names_to_fk, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='learner',
+            name='department',
+        ),
+        migrations.RemoveField(
+            model_name='learner',
+            name='section',
+        ),
+        migrations.RenameField(
+            model_name='learner',
+            old_name='department_tmp',
+            new_name='department',
+        ),
+        migrations.RenameField(
+            model_name='learner',
+            old_name='section_tmp',
+            new_name='section',
         ),
     ]


### PR DESCRIPTION
## Summary
- add data migration steps for `Learner.department` and `Learner.section`

## Testing
- `pytest -q`
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5a14c0c83329871a89691c52eba