### PR TITLE
Fix failing migration with pending triggers

### DIFF
--- a/core/migrations/0008_department_section_foreignkeys.py
+++ b/core/migrations/0008_department_section_foreignkeys.py
@@ -27,6 +27,7 @@ def copy_names_to_fk(apps, schema_editor):
         learner.save(update_fields=["department_tmp", "section_tmp"])
 
 class Migration(migrations.Migration):
+    atomic = False
     dependencies = [
         ('core', '0007_department_section_charfields'),
     ]


### PR DESCRIPTION
## Summary
- set `atomic=False` for migration that transitions char fields to foreign keys

## Testing
- `pip install --user -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851a87518148332baae01a0f76ebd76