### PR TITLE
Add other services page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -52,5 +52,9 @@ urlpatterns = [
         ),
         name="password_reset_complete",
     ),
+
+    # ✅ صفحة الخدمات الأخرى وكروت الخدمات
+    path("other-services/", views.other_services, name="other_services"),
+    path("service/<str:service>/", views.service_page, name="service_page"),
 ]
 

--- a/core/views.py
+++ b/core/views.py
@@ -190,3 +190,28 @@ def login_view(request):
         messages.error(request, "اسم المستخدم أو كلمة المرور غير صحيحة")
 
     return render(request, "core/login.html", {"form": form})
+
+
+# ---------------------------------------------------------------------------
+def other_services(request):
+    """عرض صفحة الخدمات الأخرى مع كروت الخدمات."""
+    return render(request, "core/other_services.html")
+
+
+# ---------------------------------------------------------------------------
+def service_page(request, service):
+    """عرض صفحة خدمة معينة بناءً على الاسم الممرر."""
+    service_names = {
+        "needs_analysis": "تحليل الاحتياجات التدريبية",
+        "share_knowledge": "شاركنا المعرفة",
+        "youtube_tracks": "مسارات دورات اليوتيوب",
+        "skills_program": "برنامج مهارات",
+        "articles": "مقالات",
+        "my_certificates": "شهاداتي",
+        "course_announcements": "إعلانات الدورات التدريبية",
+        "cooperative_training": "التدريب التعاوني",
+    }
+
+    name = service_names.get(service, service)
+    context = {"service_name": name}
+    return render(request, "core/service_page.html", context)

--- a/templates/core/navbar.html
+++ b/templates/core/navbar.html
@@ -7,7 +7,7 @@
     <li><a href="#">الدورات التدريبية</a></li>
     <li><a href="#">محاضرات تثقيفية</a></li>
     <li><a href="#">مسارات التعلم</a></li>
-    <li><a href="#">خدمات أخرى</a></li>
+    <li><a href="{% url 'core:other_services' %}">خدمات أخرى</a></li>
   </ul>
 
   {% if request.user.is_authenticated %}

--- a/templates/core/other_services.html
+++ b/templates/core/other_services.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block title %}الخدمات الأخرى{% endblock %}
+
+{% block content %}
+<div class="services-container">
+  <h2 class="services-title">خدمات المنصة</h2>
+  <div class="services-grid">
+    <a href="{% url 'core:service_page' service='needs_analysis' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-search"></i></div>
+      <div class="service-name">تحليل الاحتياجات التدريبية</div>
+    </a>
+    <a href="{% url 'core:service_page' service='share_knowledge' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-share-alt"></i></div>
+      <div class="service-name">شاركنا المعرفة</div>
+    </a>
+    <a href="{% url 'core:service_page' service='youtube_tracks' %}" class="service-card">
+      <div class="service-icon"><i class="fab fa-youtube"></i></div>
+      <div class="service-name">مسارات دورات اليوتيوب</div>
+    </a>
+    <a href="{% url 'core:service_page' service='skills_program' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-lightbulb"></i></div>
+      <div class="service-name">برنامج مهارات</div>
+    </a>
+    <a href="{% url 'core:service_page' service='articles' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-book-open"></i></div>
+      <div class="service-name">مقالات</div>
+    </a>
+    <a href="{% url 'core:service_page' service='my_certificates' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-certificate"></i></div>
+      <div class="service-name">شهاداتي</div>
+    </a>
+    <a href="{% url 'core:service_page' service='course_announcements' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-bullhorn"></i></div>
+      <div class="service-name">إعلانات الدورات التدريبية</div>
+    </a>
+    <a href="{% url 'core:service_page' service='cooperative_training' %}" class="service-card">
+      <div class="service-icon"><i class="fas fa-users"></i></div>
+      <div class="service-name">التدريب التعاوني</div>
+    </a>
+  </div>
+</div>
+
+<style>
+.services-container {
+  text-align: center;
+}
+.services-title {
+  @apply text-3xl font-bold text-blue-900 mb-8;
+}
+.services-grid {
+  @apply grid gap-6 md:grid-cols-2 lg:grid-cols-3;
+}
+.service-card {
+  @apply flex flex-col items-center justify-center border border-gray-200 rounded-lg p-6 transition-transform hover:shadow-lg hover:-translate-y-1;
+  background-color: #fff;
+}
+.service-icon {
+  @apply text-4xl text-blue-600 mb-3;
+}
+.service-name {
+  @apply font-semibold text-blue-900;
+}
+</style>
+{% endblock %}

--- a/templates/core/service_page.html
+++ b/templates/core/service_page.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ service_name }} | MajedLearn{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto text-center py-16">
+  <h1 class="text-3xl font-bold mb-4">{{ service_name }}</h1>
+  <p class="text-lg text-gray-700">صفحة خدمة {{ service_name }} قيد الإنشاء.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add route for other services page and generic service page
- implement `other_services` and `service_page` views
- create `other_services.html` with service cards
- create placeholder `service_page.html`
- link other services in navbar

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851b29d787c8332b3e7548e10d765b9