### PR TITLE
Configure services grid layout

### DIFF
--- a/templates/core/other_services.html
+++ b/templates/core/other_services.html
@@ -62,7 +62,7 @@
 /* شبكة الكروت */
 .services-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 32px;
   justify-items: center;
 }
@@ -71,6 +71,7 @@
   background: #fff;
   border-radius: 22px;
   box-shadow: 0 4px 18px #08347d16;
+  width: 100%;
   padding: 36px 18px 26px 18px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- keep "services" cards aligned in a grid
- enforce three columns on large screens, two on medium, and single-column on small

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6851b92fbb608332b6fe5a54e5b5f403