### PR TITLE
Add recruitment evaluation module

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,7 +1,15 @@
 # core/admin.py
 from django.contrib import admin
 
-from .models import Learner, Department, Section, Nationality, Sector
+from .models import (
+    Learner,
+    Department,
+    Section,
+    Nationality,
+    Sector,
+    RecruitmentEmployee,
+    EmployeeEvaluation,
+)
 
 
 @admin.register(Learner)
@@ -38,4 +46,16 @@ class NationalityAdmin(admin.ModelAdmin):
 class SectorAdmin(admin.ModelAdmin):
     list_display = ("name",)
     search_fields = ("name",)
+
+
+@admin.register(RecruitmentEmployee)
+class RecruitmentEmployeeAdmin(admin.ModelAdmin):
+    list_display = ("name", "project_name", "start_date")
+    search_fields = ("name", "computer_number", "project_name")
+
+
+@admin.register(EmployeeEvaluation)
+class EmployeeEvaluationAdmin(admin.ModelAdmin):
+    list_display = ("employee", "evaluator", "evaluated_at")
+    list_filter = ("evaluator",)
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from django.contrib.auth.models import User
 
 from .models import Learner, Nationality, Sector
+from .models import RecruitmentEmployee, EmployeeEvaluation
 
 
 # ـــــــ الخطوة 1: المعلومات الشخصية ـــــــ #
@@ -66,4 +67,21 @@ class LearnerStep4Form(forms.ModelForm):
             raise forms.ValidationError("كلمتا المرور غير متطابقتين")
 
         return cleaned_data
+
+
+class UploadEmployeesForm(forms.Form):
+    excel_file = forms.FileField(label="ملف Excel")
+
+
+class EmployeeEvaluationForm(forms.ModelForm):
+    class Meta:
+        model = EmployeeEvaluation
+        fields = [
+            "appearance_score",
+            "experience_score",
+            "skills_score",
+            "notes",
+            "evaluation_photo",
+            "orientation_photo",
+        ]
 

--- a/core/models.py
+++ b/core/models.py
@@ -126,3 +126,64 @@ class Learner(models.Model):
     def __str__(self) -> str:
         return f"{self.first_name_ar} {self.last_name_ar}"
 
+
+class RecruitmentEmployee(models.Model):
+    """موظفو الاستقدام الحديث المستوردون من ملفات Excel."""
+
+    name = models.CharField("الاسم", max_length=100)
+    nationality = models.CharField("الجنسية", max_length=50)
+    official_job = models.CharField("المهنة الرسمية", max_length=100)
+    actual_job = models.CharField("المهنة الفعلية", max_length=100)
+    computer_number = models.CharField("رقم الكمبيوتر", max_length=50)
+    project_name = models.CharField("اسم المشروع", max_length=100)
+    start_date = models.DateField("تاريخ المباشرة")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = "موظف استقدام"
+        verbose_name_plural = "موظفو الاستقدام"
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class EmployeeEvaluation(models.Model):
+    """تقييم موظف الاستقدام بعد المحاضرة التعريفية والتقييم العملي."""
+
+    employee = models.ForeignKey(
+        RecruitmentEmployee,
+        on_delete=models.CASCADE,
+        related_name="evaluations",
+        verbose_name="الموظف",
+    )
+    appearance_score = models.PositiveSmallIntegerField("المظهر")
+    experience_score = models.PositiveSmallIntegerField("الخبرة")
+    skills_score = models.PositiveSmallIntegerField("المهارات الفنية")
+    notes = models.TextField("ملاحظات", blank=True)
+    evaluator = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        verbose_name="المقيّم",
+    )
+    evaluation_photo = models.ImageField(
+        upload_to="evaluation_photos/",
+        null=True,
+        blank=True,
+        verbose_name="صورة التقييم",
+    )
+    orientation_photo = models.ImageField(
+        upload_to="orientation_photos/",
+        null=True,
+        blank=True,
+        verbose_name="صورة المحاضرة",
+    )
+    evaluated_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = "تقييم موظف"
+        verbose_name_plural = "تقييمات الموظفين"
+
+    def __str__(self) -> str:
+        return f"{self.employee.name} - {self.evaluator}" if self.evaluator else self.employee.name
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -56,5 +56,9 @@ urlpatterns = [
     # ✅ صفحة الخدمات الأخرى وكروت الخدمات
     path("other-services/", views.other_services, name="other_services"),
     path("service/<str:service>/", views.service_page, name="service_page"),
+
+    # استقدام الحديث
+    path("recruitment/upload/", views.upload_employees, name="upload_employees"),
+    path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
 ]
 

--- a/core/views.py
+++ b/core/views.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.core.mail import send_mail
 from django.contrib.sites.shortcuts import get_current_site
 import re
+from openpyxl import load_workbook
 
 from .models import (
     Learner,
@@ -18,7 +19,11 @@ from .models import (
     Sector,
     Department,
     Section,
+    RecruitmentEmployee,
+    EmployeeEvaluation,
 )
+
+from .forms import UploadEmployeesForm, EmployeeEvaluationForm
 
 
 # ---------------------------------------------------------------------------
@@ -219,3 +224,57 @@ def service_page(request, service):
     name = service_names.get(service, service)
     context = {"service_name": name}
     return render(request, "core/service_page.html", context)
+
+
+# ---------------------------------------------------------------------------
+def upload_employees(request):
+    """تحميل ملف Excel واستيراد بيانات الموظفين."""
+    if request.method == "POST":
+        form = UploadEmployeesForm(request.POST, request.FILES)
+        if form.is_valid():
+            wb = load_workbook(form.cleaned_data["excel_file"])
+            sheet = wb.active
+            for row in sheet.iter_rows(min_row=2, values_only=True):
+                if not any(row):
+                    continue
+                RecruitmentEmployee.objects.create(
+                    name=row[0],
+                    nationality=row[1],
+                    official_job=row[2],
+                    actual_job=row[3],
+                    computer_number=str(row[4]),
+                    project_name=row[5],
+                    start_date=row[6],
+                )
+            messages.success(request, "تم استيراد الموظفين بنجاح")
+            return redirect("core:upload_employees")
+    else:
+        form = UploadEmployeesForm()
+    employees = RecruitmentEmployee.objects.all().order_by("-created_at")
+    return render(
+        request,
+        "core/upload_employees.html",
+        {"form": form, "employees": employees},
+    )
+
+
+# ---------------------------------------------------------------------------
+def evaluate_employee(request, pk):
+    """تعبئة استمارة تقييم موظف معين."""
+    employee = RecruitmentEmployee.objects.get(pk=pk)
+    if request.method == "POST":
+        form = EmployeeEvaluationForm(request.POST, request.FILES)
+        if form.is_valid():
+            evaluation = form.save(commit=False)
+            evaluation.employee = employee
+            evaluation.evaluator = request.user if request.user.is_authenticated else None
+            evaluation.save()
+            messages.success(request, "تم حفظ التقييم")
+            return redirect("core:evaluate_employee", pk=employee.pk)
+    else:
+        form = EmployeeEvaluationForm()
+    return render(
+        request,
+        "core/evaluate_employee.html",
+        {"form": form, "employee": employee},
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==5.2.2
 psycopg2-binary
 python-dotenv
+openpyxl
+Pillow

--- a/templates/core/evaluate_employee.html
+++ b/templates/core/evaluate_employee.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}تقييم الموظف{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">تقييم {{ employee.name }}</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">حفظ</button>
+</form>
+{% endblock %}

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block title %}تحميل الموظفين{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">تحميل كشوف الموظفين</h1>
+<form method="post" enctype="multipart/form-data" class="mb-6 space-y-4">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">رفع</button>
+</form>
+<table class="min-w-full divide-y divide-gray-200">
+  <thead>
+    <tr>
+      <th class="px-2">الاسم</th>
+      <th class="px-2">المشروع</th>
+      <th class="px-2">التاريخ</th>
+      <th class="px-2">تقييم</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for emp in employees %}
+    <tr>
+      <td class="px-2">{{ emp.name }}</td>
+      <td class="px-2">{{ emp.project_name }}</td>
+      <td class="px-2">{{ emp.start_date }}</td>
+      <td class="px-2">
+        <a href="{% url 'core:evaluate_employee' emp.pk %}" class="text-blue-600">تقييم</a>
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="4" class="text-center">لا توجد بيانات</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create models for recruitment employees and evaluations
- register new models in admin
- provide forms and views to upload Excel sheets and evaluate employees
- add routes and simple templates for these pages
- include openpyxl and Pillow in requirements

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685281f21ee083328a41d52573f41e8e