### PR TITLE
Fix recruitment evaluation link

### DIFF
--- a/templates/core/my_works.html
+++ b/templates/core/my_works.html
@@ -15,10 +15,10 @@
       <div class="work-icon"><i class="fas fa-laptop"></i></div>
       <div class="work-name">الدورات التدريبية - أون لاين</div>
     </div>
-    <div class="work-card">
+    <a href="{% url 'core:upload_employees' %}" class="work-card">
       <div class="work-icon"><i class="fas fa-check-circle"></i></div>
       <div class="work-name">تقييم الإستقدام الحديث</div>
-    </div>
+    </a>
     <div class="work-card">
       <div class="work-icon"><i class="fas fa-handshake"></i></div>
       <div class="work-name">التدريب التعاوني</div>


### PR DESCRIPTION
## Summary
- link the recruitment evaluation card to the upload employees page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685283fd50f88332ab7eb363ecf0a5c5