### PR TITLE
Add recruitment dashboard and Haramain option

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -71,6 +71,15 @@ class LearnerStep4Form(forms.ModelForm):
 
 class UploadEmployeesForm(forms.Form):
     excel_file = forms.FileField(label="ملف Excel")
+    HARAMAIN_CHOICES = [
+        ("true", "حرمين"),
+        ("false", "غير حرمين"),
+    ]
+    is_haramain = forms.ChoiceField(
+        choices=HARAMAIN_CHOICES,
+        label="نوع الكشف",
+        widget=forms.Select(),
+    )
 
 
 class EmployeeEvaluationForm(forms.ModelForm):

--- a/core/models.py
+++ b/core/models.py
@@ -137,6 +137,7 @@ class RecruitmentEmployee(models.Model):
     computer_number = models.CharField("رقم الكمبيوتر", max_length=50)
     project_name = models.CharField("اسم المشروع", max_length=100)
     start_date = models.DateField("تاريخ المباشرة")
+    is_haramain = models.BooleanField("حرمين", default=False)
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
@@ -178,6 +179,7 @@ class EmployeeEvaluation(models.Model):
         blank=True,
         verbose_name="صورة المحاضرة",
     )
+    is_haramain = models.BooleanField("حرمين", default=False)
     evaluated_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/core/urls.py
+++ b/core/urls.py
@@ -7,6 +7,8 @@ app_name = "core"
 urlpatterns = [
     # ✅ الصفحة الرئيسية
     path("", views.home, name="home"),
+    path("recruitment/", views.recruitment_dashboard, name="recruitment_dashboard"),
+    path("recruitment/step/<str:page>/", views.recruitment_placeholder, name="recruitment_step"),
 
     # ✅ صفحات التسجيل
     path("register/", views.register, name="register"),

--- a/core/views.py
+++ b/core/views.py
@@ -40,6 +40,17 @@ def home(request):
 
 
 # ---------------------------------------------------------------------------
+def recruitment_dashboard(request):
+    """الواجهة الرئيسية لخطوات تقييم موظفي الاستقدام."""
+    return render(request, "core/recruitment_dashboard.html")
+
+
+def recruitment_placeholder(request, page):
+    """صفحات مبدئية لكل مرحلة."""
+    return render(request, "core/recruitment_placeholder.html", {"page": page})
+
+
+# ---------------------------------------------------------------------------
 def register(request):
     """تسجيل متدرّب جديد ثم إرسال رابط التفعيل إلى بريده الإلكتروني."""
 
@@ -234,6 +245,7 @@ def upload_employees(request):
     if request.method == "POST":
         form = UploadEmployeesForm(request.POST, request.FILES)
         if form.is_valid():
+            is_haramain = form.cleaned_data["is_haramain"] == "true"
             df = pd.read_excel(
                 form.cleaned_data["excel_file"],
                 header=None,
@@ -251,6 +263,7 @@ def upload_employees(request):
                     computer_number=str(row[1]),
                     project_name=row[7],
                     start_date=timezone.localdate(),
+                    is_haramain=is_haramain,
                 )
             messages.success(request, "تم استيراد الموظفين بنجاح")
             return redirect("core:upload_employees")
@@ -274,6 +287,7 @@ def evaluate_employee(request, pk):
             evaluation = form.save(commit=False)
             evaluation.employee = employee
             evaluation.evaluator = request.user if request.user.is_authenticated else None
+            evaluation.is_haramain = employee.is_haramain
             evaluation.save()
             messages.success(request, "تم حفظ التقييم")
             return redirect("core:evaluate_employee", pk=employee.pk)

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+
+{% block main_class %}page-content w-full px-2 py-6{% endblock %}
+
+{% block title %}رفع كشوف الموظفين{% endblock %}
+
+{% block content %}
+<div class="recruitment-container">
+  <div class="recruitment-grid">
+    <a href="{% url 'core:recruitment_step' 'forms' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-file-alt"></i></div>
+      <div class="recruitment-name">إصدار نماذج التقييم</div>
+    </a>
+    <a href="{% url 'core:recruitment_step' 'input' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-keyboard"></i></div>
+      <div class="recruitment-name">إدخال نتائج التقييم</div>
+    </a>
+    <a href="{% url 'core:recruitment_step' 'update_db' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-database"></i></div>
+      <div class="recruitment-name">تحديث قاعدة البيانات</div>
+    </a>
+    <a href="{% url 'core:recruitment_step' 'upload_results' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-upload"></i></div>
+      <div class="recruitment-name">رفع نتائج التقييم</div>
+    </a>
+    <a href="{% url 'core:recruitment_step' 'upload_photos' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-camera"></i></div>
+      <div class="recruitment-name">رفع صور التقييم والمحاضرة التعريفية</div>
+    </a>
+    <a href="{% url 'core:recruitment_step' 'attendance' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-list"></i></div>
+      <div class="recruitment-name">إصدار كشف الحضور والغياب</div>
+    </a>
+  </div>
+</div>
+{% endblock %}
+
+<style>
+.recruitment-container {
+  width: 100%;
+  margin: 0;
+  padding: 20px 0 30px;
+  background: #fff;
+  border-radius: 18px;
+}
+.recruitment-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 32px;
+  justify-items: center;
+}
+.recruitment-card {
+  background: #fff;
+  border-radius: 22px;
+  box-shadow: 0 4px 18px #08347d16;
+  width: 100%;
+  padding: 36px 18px 26px 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: box-shadow 0.18s, transform 0.18s;
+  text-decoration: none;
+}
+.recruitment-card:hover {
+  box-shadow: 0 10px 28px #00cc0033;
+  transform: translateY(-3px) scale(1.03);
+  background: linear-gradient(120deg, #e6f6ea 60%, #f5f5ff 100%);
+}
+.recruitment-icon {
+  background: #002366;
+  color: #fff;
+  border-radius: 50%;
+  width: 70px;
+  height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  margin-bottom: 18px;
+  box-shadow: 0 2px 10px #08347d33;
+}
+.recruitment-name {
+  font-size: 1.15rem;
+  font-weight: bold;
+  color: #002366;
+  margin-top: 8px;
+  text-align: center;
+}
+@media (max-width: 900px) {
+  .recruitment-grid { grid-template-columns: 1fr 1fr; gap: 18px; }
+}
+@media (max-width: 600px) {
+  .recruitment-grid { grid-template-columns: 1fr; gap: 14px; }
+}
+</style>

--- a/templates/core/recruitment_placeholder.html
+++ b/templates/core/recruitment_placeholder.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page }}{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">{{ page }}</h1>
+<p>هذه الصفحة قيد التطوير.</p>
+{% endblock %}

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -13,6 +13,7 @@
       <th class="px-2">الاسم</th>
       <th class="px-2">المشروع</th>
       <th class="px-2">التاريخ</th>
+      <th class="px-2">حرمين؟</th>
       <th class="px-2">تقييم</th>
     </tr>
   </thead>
@@ -22,6 +23,7 @@
       <td class="px-2">{{ emp.name }}</td>
       <td class="px-2">{{ emp.project_name }}</td>
       <td class="px-2">{{ emp.start_date }}</td>
+      <td class="px-2">{{ emp.is_haramain|yesno:"نعم,لا" }}</td>
       <td class="px-2">
         <a href="{% url 'core:evaluate_employee' emp.pk %}" class="text-blue-600">تقييم</a>
       </td>


### PR DESCRIPTION
## Summary
- create recruitment dashboard with 6 steps
- allow selecting "حرمين" on employee upload and store it
- propagate Haramain info to evaluations
- show Haramain column in employee list

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py makemigrations --noinput` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685290caadf883329bfb8b3dae00044b