### PR TITLE
Fix missing is_haramain column

### DIFF
--- a/core/migrations/0010_add_is_haramain.py
+++ b/core/migrations/0010_add_is_haramain.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0009_recruitment_models'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='recruitmentemployee',
+            name='is_haramain',
+            field=models.BooleanField(default=False, verbose_name='حرمين'),
+        ),
+        migrations.AddField(
+            model_name='employeeevaluation',
+            name='is_haramain',
+            field=models.BooleanField(default=False, verbose_name='حرمين'),
+        ),
+    ]


### PR DESCRIPTION
## Summary
- add migration for `is_haramain` fields in recruitment models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685292935af88332897a46c75459d4b9