### PR TITLE
Add upload employees card to recruitment dashboard

### DIFF
--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -7,6 +7,10 @@
 {% block content %}
 <div class="recruitment-container">
   <div class="recruitment-grid">
+    <a href="{% url 'core:upload_employees' %}" class="recruitment-card">
+      <div class="recruitment-icon"><i class="fas fa-users"></i></div>
+      <div class="recruitment-name">رفع كشف الموظفين</div>
+    </a>
     <a href="{% url 'core:recruitment_step' 'forms' %}" class="recruitment-card">
       <div class="recruitment-icon"><i class="fas fa-file-alt"></i></div>
       <div class="recruitment-name">إصدار نماذج التقييم</div>


### PR DESCRIPTION
## Summary
- add missing card that links to the employee upload page

## Testing
- `pytest -q`
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68529c706cb483329a73950756107a7c