### PR TITLE
Add hierarchical employee view with inline final score

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -50,7 +50,7 @@ class SectorAdmin(admin.ModelAdmin):
 
 @admin.register(RecruitmentEmployee)
 class RecruitmentEmployeeAdmin(admin.ModelAdmin):
-    list_display = ("name", "project_name", "start_date")
+    list_display = ("name", "project_name", "start_date", "final_score")
     search_fields = ("name", "computer_number", "project_name")
 
 

--- a/core/migrations/0011_add_final_score.py
+++ b/core/migrations/0011_add_final_score.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0010_add_is_haramain'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='recruitmentemployee',
+            name='final_score',
+            field=models.FloatField(null=True, blank=True, verbose_name='الدرجة النهائية'),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -139,6 +139,7 @@ class RecruitmentEmployee(models.Model):
     start_date = models.DateField("تاريخ المباشرة")
     is_haramain = models.BooleanField("حرمين", default=False)
     created_at = models.DateTimeField(auto_now_add=True)
+    final_score = models.FloatField("الدرجة النهائية", null=True, blank=True)
 
     class Meta:
         verbose_name = "موظف استقدام"

--- a/core/urls.py
+++ b/core/urls.py
@@ -62,5 +62,6 @@ urlpatterns = [
     # استقدام الحديث
     path("recruitment/upload/", views.upload_employees, name="upload_employees"),
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
+    path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),
 ]
 

--- a/core/views.py
+++ b/core/views.py
@@ -14,6 +14,7 @@ import re
 from openpyxl import load_workbook
 import pandas as pd
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 
 from .models import (
     Learner,
@@ -270,10 +271,26 @@ def upload_employees(request):
     else:
         form = UploadEmployeesForm()
     employees = RecruitmentEmployee.objects.all().order_by("-created_at")
+
+    grouped = {}
+    for emp in employees:
+        dt = timezone.localtime(emp.created_at).date()
+        grouped.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(emp)
+
+    sorted_grouped = []
+    for year in sorted(grouped.keys(), reverse=True):
+        months = []
+        for month in sorted(grouped[year].keys(), reverse=True):
+            days = []
+            for day in sorted(grouped[year][month].keys(), reverse=True):
+                days.append({"day": day, "employees": grouped[year][month][day]})
+            months.append({"month": month, "days": days})
+        sorted_grouped.append({"year": year, "months": months})
+
     return render(
         request,
         "core/upload_employees.html",
-        {"form": form, "employees": employees},
+        {"form": form, "grouped": sorted_grouped},
     )
 
 
@@ -298,3 +315,17 @@ def evaluate_employee(request, pk):
         "core/evaluate_employee.html",
         {"form": form, "employee": employee},
     )
+
+
+@require_POST
+def set_final_score(request, pk):
+    """تعديل الدرجة النهائية لموظف معين."""
+    employee = RecruitmentEmployee.objects.get(pk=pk)
+    score = request.POST.get("final_score")
+    try:
+        employee.final_score = float(score)
+    except (TypeError, ValueError):
+        pass
+    else:
+        employee.save()
+    return redirect("core:upload_employees")

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -7,30 +7,50 @@
   {{ form.as_p }}
   <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">رفع</button>
 </form>
-<table class="min-w-full divide-y divide-gray-200">
-  <thead>
-    <tr>
-      <th class="px-2">الاسم</th>
-      <th class="px-2">المشروع</th>
-      <th class="px-2">التاريخ</th>
-      <th class="px-2">حرمين؟</th>
-      <th class="px-2">تقييم</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for emp in employees %}
-    <tr>
-      <td class="px-2">{{ emp.name }}</td>
-      <td class="px-2">{{ emp.project_name }}</td>
-      <td class="px-2">{{ emp.start_date }}</td>
-      <td class="px-2">{{ emp.is_haramain|yesno:"نعم,لا" }}</td>
-      <td class="px-2">
-        <a href="{% url 'core:evaluate_employee' emp.pk %}" class="text-blue-600">تقييم</a>
-      </td>
-    </tr>
-    {% empty %}
-    <tr><td colspan="4" class="text-center">لا توجد بيانات</td></tr>
+
+{% for year in grouped %}
+<details class="mb-4">
+  <summary class="cursor-pointer font-bold">{{ year.year }}</summary>
+  {% for month in year.months %}
+  <details class="ml-4 mb-3">
+    <summary class="cursor-pointer font-semibold">الشهر {{ month.month }}</summary>
+    {% for day in month.days %}
+    <details class="ml-8 mb-2">
+      <summary class="cursor-pointer">اليوم {{ day.day }}</summary>
+      <table class="min-w-full divide-y divide-gray-200 my-2">
+        <thead>
+          <tr>
+            <th class="px-2">الاسم</th>
+            <th class="px-2">المشروع</th>
+            <th class="px-2">التاريخ</th>
+            <th class="px-2">حرمين؟</th>
+            <th class="px-2">الدرجة النهائية</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for emp in day.employees %}
+          <tr>
+            <td class="px-2">{{ emp.name }}</td>
+            <td class="px-2">{{ emp.project_name }}</td>
+            <td class="px-2">{{ emp.start_date }}</td>
+            <td class="px-2">{{ emp.is_haramain|yesno:"نعم,لا" }}</td>
+            <td class="px-2">
+              <form method="post" action="{% url 'core:set_final_score' emp.pk %}" class="flex space-x-1 items-center">
+                {% csrf_token %}
+                <input type="number" step="0.01" name="final_score" value="{{ emp.final_score|default_if_none:'' }}" class="border px-2 w-20 text-sm">
+                <button type="submit" class="px-2 text-green-600">حفظ</button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </details>
     {% endfor %}
-  </tbody>
-</table>
+  </details>
+  {% endfor %}
+</details>
+{% empty %}
+<p>لا توجد بيانات</p>
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow storing a final score on `RecruitmentEmployee`
- group employees by year/month/day when displaying upload results
- enable entering final score directly from the uploads page

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529e567e2c8332954145d93e627c7c