### PR TITLE
Document migration step for new database fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ DJANGO_SECRET_KEY
 
 A local `db.sqlite3` file was previously tracked but is now removed. Ensure your
 PostgreSQL server is running and the variables above are set when running
-migrations or tests.
+migrations or tests. Whenever new fields are added (for example `final_score`
+in the recruitment module) make sure to apply migrations:
+
+```
+python manage.py migrate
+```
+
+Failing to run migrations can lead to errors such as
+`ProgrammingError: column core_recruitmentemployee.final_score does not exist`.
 
 Ensure `DJANGO_SECRET_KEY` is set to a unique value in production to avoid using
 the default key from `settings.py`.


### PR DESCRIPTION
## Summary
- add note about applying migrations when new fields are added
- mention the final_score error as an example and show `python manage.py migrate`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68529fd447808332ae3419e28cc70caa