### PR TITLE
Add bulk evaluation input page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -62,6 +62,6 @@ urlpatterns = [
     # استقدام الحديث
     path("recruitment/upload/", views.upload_employees, name="upload_employees"),
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
+    path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),
     path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),
-]
 

--- a/core/views.py
+++ b/core/views.py
@@ -14,6 +14,7 @@ import re
 from openpyxl import load_workbook
 import pandas as pd
 from django.utils import timezone
+import datetime
 from django.views.decorators.http import require_POST
 
 from .models import (
@@ -329,3 +330,63 @@ def set_final_score(request, pk):
     else:
         employee.save()
     return redirect("core:upload_employees")
+
+# ---------------------------------------------------------------------------
+def input_evaluation_results(request):
+    """إدخال الدرجات لعدد من الموظفين دفعة واحدة."""
+    employees = RecruitmentEmployee.objects.all().order_by("created_at")
+
+    grouped = {}
+    for emp in employees:
+        dt = timezone.localtime(emp.created_at).date()
+        grouped.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(emp)
+
+    year = request.GET.get("year")
+    month = request.GET.get("month")
+    day = request.GET.get("day")
+    selected = []
+
+    if request.method == "POST":
+        year = request.POST.get("year")
+        month = request.POST.get("month")
+        day = request.POST.get("day")
+        try:
+            y = int(year)
+            m = int(month)
+            d = int(day)
+            selected = grouped.get(y, {}).get(m, {}).get(d, [])
+        except (TypeError, ValueError):
+            selected = []
+        for emp in selected:
+            score = request.POST.get(f"score_{emp.id}")
+            if score:
+                try:
+                    emp.final_score = float(score)
+                    emp.save()
+                except ValueError:
+                    pass
+        messages.success(request, "تم حفظ الدرجات")
+        return redirect(f"{reverse('core:input_evaluation_results')}?year={year}&month={month}&day={day}")
+    else:
+        try:
+            y = int(year)
+            m = int(month)
+            d = int(day)
+            selected = grouped.get(y, {}).get(m, {}).get(d, [])
+        except (TypeError, ValueError):
+            selected = []
+
+    years = sorted(grouped.keys(), reverse=True)
+    months = sorted(grouped.get(int(year), {}).keys(), reverse=True) if year and year.isdigit() else []
+    days = sorted(grouped.get(int(year), {}).get(int(month), {}).keys(), reverse=True) if year and month and year.isdigit() and month.isdigit() else []
+
+    context = {
+        "years": years,
+        "months": months,
+        "days": days,
+        "selected_year": year,
+        "selected_month": month,
+        "selected_day": day,
+        "employees": selected,
+    }
+    return render(request, "core/input_results.html", context)

--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -1,0 +1,65 @@
+{% extends 'base.html' %}
+{% block title %}إدخال نتائج التقييم{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">إدخال نتائج التقييم</h1>
+<form method="get" class="flex space-x-2 mb-4">
+  <select name="year" class="border px-2 py-1">
+    <option value="">السنة...</option>
+    {% for y in years %}
+    <option value="{{ y }}" {% if y|stringformat:'s' == selected_year %}selected{% endif %}>{{ y }}</option>
+    {% endfor %}
+  </select>
+  <select name="month" class="border px-2 py-1">
+    <option value="">الشهر...</option>
+    {% for m in months %}
+    <option value="{{ m }}" {% if m|stringformat:'s' == selected_month %}selected{% endif %}>{{ m }}</option>
+    {% endfor %}
+  </select>
+  <select name="day" class="border px-2 py-1">
+    <option value="">اليوم...</option>
+    {% for d in days %}
+    <option value="{{ d }}" {% if d|stringformat:'s' == selected_day %}selected{% endif %}>{{ d }}</option>
+    {% endfor %}
+  </select>
+  <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">عرض</button>
+</form>
+{% if employees %}
+<form method="post">
+  {% csrf_token %}
+  <input type="hidden" name="year" value="{{ selected_year }}">
+  <input type="hidden" name="month" value="{{ selected_month }}">
+  <input type="hidden" name="day" value="{{ selected_day }}">
+  <table class="min-w-full divide-y divide-gray-200 mb-4">
+    <thead>
+      <tr>
+        <th class="px-2">#</th>
+        <th class="px-2">رقم الكمبيوتر</th>
+        <th class="px-2">الاسم</th>
+        <th class="px-2">الجنسية</th>
+        <th class="px-2">المهنة</th>
+        <th class="px-2">اسم المشروع</th>
+        <th class="px-2">الدرجة النهائية</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for emp in employees %}
+      <tr>
+        <td class="px-2 text-center">{{ forloop.counter }}</td>
+        <td class="px-2">{{ emp.computer_number }}</td>
+        <td class="px-2">{{ emp.name }}</td>
+        <td class="px-2">{{ emp.nationality }}</td>
+        <td class="px-2">{{ emp.official_job }}</td>
+        <td class="px-2">{{ emp.project_name }}</td>
+        <td class="px-2">
+          <input type="number" step="0.01" name="score_{{ emp.id }}" value="{{ emp.final_score|default_if_none:'' }}" class="border px-2 w-20 text-sm">
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">حفظ جميع الدرجات</button>
+</form>
+{% elif selected_year and selected_month and selected_day %}
+<p>لا توجد بيانات لهذا التاريخ.</p>
+{% endif %}
+{% endblock %}

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -15,7 +15,7 @@
       <div class="recruitment-icon"><i class="fas fa-file-alt"></i></div>
       <div class="recruitment-name">إصدار نماذج التقييم</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'input' %}" class="recruitment-card">
+    <a href="{% url 'core:input_evaluation_results' %}" class="recruitment-card">
       <div class="recruitment-icon"><i class="fas fa-keyboard"></i></div>
       <div class="recruitment-name">إدخال نتائج التقييم</div>
     </a>


### PR DESCRIPTION
## Summary
- create new bulk evaluation input view and url
- show date selection and bulk grading table
- link to new page from recruitment dashboard

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852c196c8a88332af5c76478a90afcd