### PR TITLE
Fix SyntaxError in core URLs

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -64,4 +64,4 @@ urlpatterns = [
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
     path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),
     path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),
-
+]


### PR DESCRIPTION
## Summary
- close `urlpatterns` list in `core/urls.py`

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6852c36b5cf88332a825227b6417733c