### PR TITLE
Add missing columns to evaluation results page

### DIFF
--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -33,26 +33,34 @@
     <thead>
       <tr>
         <th class="px-2">#</th>
-        <th class="px-2">رقم الكمبيوتر</th>
-        <th class="px-2">الاسم</th>
+        <th class="px-2">الرقم الوظيفي</th>
+        <th class="px-2">الاسم (ع)</th>
+        <th class="px-2">الاسم (En)</th>
+        <th class="px-2">رقم الجواز</th>
         <th class="px-2">الجنسية</th>
         <th class="px-2">المهنة</th>
-        <th class="px-2">اسم المشروع</th>
-        <th class="px-2">الدرجة النهائية</th>
+        <th class="px-2">اسم الكفيل</th>
+        <th class="px-2">Evaluation</th>
+        <th class="px-2">Result</th>
+        <th class="px-2">Result Expectations</th>
       </tr>
     </thead>
     <tbody>
       {% for emp in employees %}
       <tr>
         <td class="px-2 text-center">{{ forloop.counter }}</td>
-        <td class="px-2">{{ emp.computer_number }}</td>
+        <td class="px-2">{{ emp.employee_number|default:emp.computer_number }}</td>
         <td class="px-2">{{ emp.name }}</td>
+        <td class="px-2">{{ emp.name_en }}</td>
+        <td class="px-2">{{ emp.passport_number }}</td>
         <td class="px-2">{{ emp.nationality }}</td>
         <td class="px-2">{{ emp.official_job }}</td>
-        <td class="px-2">{{ emp.project_name }}</td>
+        <td class="px-2">{{ emp.sponsor_name }}</td>
         <td class="px-2">
           <input type="number" step="0.01" name="score_{{ emp.id }}" value="{{ emp.final_score|default_if_none:'' }}" class="border px-2 w-20 text-sm">
         </td>
+        <td class="px-2">{{ emp.final_score }}</td>
+        <td class="px-2">{{ emp.result_expectations }}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- show more fields in evaluation results table

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_6852c910b234833294033cf00d31e243