### PR TITLE
Fix static tag loading in recruitment dashboard

### DIFF
--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block main_class %}page-content w-full px-2 py-6{% endblock %}
 


### PR DESCRIPTION
## Summary
- load the static template library in the `recruitment_dashboard.html` template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685551bd87548332a73c99c984efb5e9