### PR TITLE
Add debug lines for recruitment dashboard

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -16,6 +16,7 @@ import pandas as pd
 from django.utils import timezone
 import datetime
 from django.views.decorators.http import require_POST
+import os
 
 from .models import (
     Learner,
@@ -44,6 +45,8 @@ def home(request):
 # ---------------------------------------------------------------------------
 def recruitment_dashboard(request):
     """الواجهة الرئيسية لخطوات تقييم موظفي الاستقدام."""
+    print("Rendering template: core/recruitment_dashboard.html")
+    print("Template absolute path:", os.path.abspath(__file__))
     return render(request, "core/recruitment_dashboard.html")
 
 

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load static %}
 
+<h1 style="color:red;">THIS IS THE CORRECT TEMPLATE</h1>
+
 {% block main_class %}page-content w-full px-2 py-6{% endblock %}
 
 {% block title %}الاستقدام الحديث{% endblock %}


### PR DESCRIPTION
## Summary
- insert visible debug header in `recruitment_dashboard.html`
- print debug info from `recruitment_dashboard` view

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855678b278883328e3a59cecab01b7a