### PR TITLE
Add debug line in recruitment template correctly

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -16,6 +16,7 @@ import pandas as pd
 from django.utils import timezone
 import datetime
 from django.views.decorators.http import require_POST
+import os
 
 from .models import (
     Learner,
@@ -44,6 +45,8 @@ def home(request):
 # ---------------------------------------------------------------------------
 def recruitment_dashboard(request):
     """الواجهة الرئيسية لخطوات تقييم موظفي الاستقدام."""
+    print("Rendering template: core/recruitment_dashboard.html")
+    print("Template absolute path:", os.path.abspath(__file__))
     return render(request, "core/recruitment_dashboard.html")
 
 

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -6,6 +6,7 @@
 {% block title %}الاستقدام الحديث{% endblock %}
 
 {% block content %}
+<h1 style="color:red;">THIS IS THE CORRECT TEMPLATE</h1>
 <div class="recruitment-container">
   <div class="recruitment-header">
     <img src="{% static 'images/recruitment_portal.svg' %}" style="width:100px;opacity:0.95;margin-bottom:8px;" alt="Recruitment Portal Logo">
@@ -42,9 +43,6 @@
       <div class="recruitment-name">إصدار كشف الحضور والغياب</div>
     </a>
   </div>
-</div>
-{% endblock %}
-
 <style>
 .recruitment-container {
   max-width: 1100px;
@@ -142,5 +140,6 @@
   .recruitment-container { padding: 10px 2px 20px;}
   .recruitment-grid { grid-template-columns: 1fr; gap: 14px; }
   .recruitment-card {padding: 26px 5px 18px;}
-}
+  }
 </style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- fix debug header placement inside `recruitment_dashboard.html`
- move embedded styles inside the content block so the grid CSS loads

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855678b278883328e3a59cecab01b7a