### PR TITLE
Add RecruitmentReport upload and archive

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -9,6 +9,7 @@ from .models import (
     Sector,
     RecruitmentEmployee,
     EmployeeEvaluation,
+    RecruitmentReport,
 )
 
 
@@ -58,4 +59,10 @@ class RecruitmentEmployeeAdmin(admin.ModelAdmin):
 class EmployeeEvaluationAdmin(admin.ModelAdmin):
     list_display = ("employee", "evaluator", "evaluated_at")
     list_filter = ("evaluator",)
+
+
+@admin.register(RecruitmentReport)
+class RecruitmentReportAdmin(admin.ModelAdmin):
+    list_display = ("filename", "report_date", "uploaded_at")
+    search_fields = ("filename",)
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -82,6 +82,14 @@ class UploadEmployeesForm(forms.Form):
     )
 
 
+class RecruitmentReportForm(forms.Form):
+    file = forms.FileField(label="كشف الاستقدام (Excel)")
+    report_date = forms.DateField(
+        label="تاريخ الكشف",
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+
+
 class EmployeeEvaluationForm(forms.ModelForm):
     class Meta:
         model = EmployeeEvaluation

--- a/core/models.py
+++ b/core/models.py
@@ -208,3 +208,28 @@ class EmployeeEvaluation(models.Model):
     def __str__(self) -> str:
         return f"{self.employee.name} - {self.evaluator}" if self.evaluator else self.employee.name
 
+
+class RecruitmentReport(models.Model):
+    """تمثيل كشف استقدام كامل كما هو مرفوع من ملف Excel."""
+
+    filename = models.CharField("اسم الملف", max_length=255)
+    uploaded_at = models.DateTimeField("تاريخ الرفع", auto_now_add=True)
+    uploaded_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        verbose_name="تم الرفع بواسطة",
+    )
+    report_date = models.DateField("تاريخ الكشف")
+    columns = models.JSONField("الأعمدة")
+    rows = models.JSONField("الصفوف")
+
+    class Meta:
+        unique_together = ("filename", "report_date")
+        verbose_name = "كشف استقدام"
+        verbose_name_plural = "كشوف الاستقدام"
+
+    def __str__(self) -> str:
+        return f"{self.filename} - {self.report_date}"
+

--- a/core/templatetags/recruitment_extras.py
+++ b/core/templatetags/recruitment_extras.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def get_item(data, key):
+    """Get item from a dict by key."""
+    if isinstance(data, dict):
+        return data.get(key, "")
+    return ""

--- a/core/urls.py
+++ b/core/urls.py
@@ -61,6 +61,7 @@ urlpatterns = [
 
     # استقدام الحديث
     path("recruitment/upload/", views.upload_employees, name="upload_employees"),
+    path("recruitment/report/<int:pk>/", views.report_detail, name="report_detail"),
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
     path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),
     path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),

--- a/core/views.py
+++ b/core/views.py
@@ -26,9 +26,13 @@ from .models import (
     Section,
     RecruitmentEmployee,
     EmployeeEvaluation,
+    RecruitmentReport,
 )
 
-from .forms import UploadEmployeesForm, EmployeeEvaluationForm
+from .forms import (
+    EmployeeEvaluationForm,
+    RecruitmentReportForm,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -246,62 +250,53 @@ def service_page(request, service):
 
 # ---------------------------------------------------------------------------
 def upload_employees(request):
-    """تحميل ملف Excel واستيراد بيانات الموظفين."""
+    """رفع كشوف الموظفين وتخزينها كما هي في قاعدة البيانات."""
+
     if request.method == "POST":
-        form = UploadEmployeesForm(request.POST, request.FILES)
+        form = RecruitmentReportForm(request.POST, request.FILES)
         if form.is_valid():
-            is_haramain = form.cleaned_data["is_haramain"] == "true"
-            df = pd.read_excel(
-                form.cleaned_data["excel_file"],
-                header=None,
-                skiprows=1,
+            excel = form.cleaned_data["file"]
+            report_date = form.cleaned_data["report_date"]
+
+            if RecruitmentReport.objects.filter(
+                filename=excel.name, report_date=report_date
+            ).exists():
+                messages.error(request, "تم رفع هذا الكشف مسبقاً")
+                return redirect("core:upload_employees")
+
+            df = pd.read_excel(excel)
+            columns = df.columns.tolist()
+            rows = df.fillna("").to_dict(orient="records")
+
+            RecruitmentReport.objects.create(
+                filename=excel.name,
+                uploaded_by=request.user if request.user.is_authenticated else None,
+                report_date=report_date,
+                columns=columns,
+                rows=rows,
             )
-            for values in df.itertuples(index=False):
-                row = list(values)
-                if not any(pd.notna(cell) for cell in row):
-                    continue
-                RecruitmentEmployee.objects.create(
-                    serial=row[0],
-                    employee_number=str(row[1]),
-                    name=row[2],
-                    name_en=row[3],
-                    passport_number=row[4],
-                    nationality=row[5],
-                    official_job=row[6],
-                    sponsor_name=row[7],
-                    evaluation=row[8],
-                    result=row[9],
-                    result_expectations=row[10],
-                    start_date=timezone.localdate(),
-                    is_haramain=is_haramain,
-                    final_score=row[8] if pd.notna(row[8]) else None,
-                )
-            messages.success(request, "تم استيراد الموظفين بنجاح")
+            messages.success(request, "تم حفظ الكشف بنجاح")
             return redirect("core:upload_employees")
     else:
-        form = UploadEmployeesForm()
-    employees = RecruitmentEmployee.objects.all().order_by("-created_at")
+        form = RecruitmentReportForm()
 
-    grouped = {}
-    for emp in employees:
-        dt = timezone.localtime(emp.created_at).date()
-        grouped.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(emp)
+    reports_qs = RecruitmentReport.objects.all().order_by("-report_date")
+    reports = {}
+    for rep in reports_qs:
+        dt = rep.report_date
+        reports.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(rep)
 
-    sorted_grouped = []
-    for year in sorted(grouped.keys(), reverse=True):
-        months = []
-        for month in sorted(grouped[year].keys(), reverse=True):
-            days = []
-            for day in sorted(grouped[year][month].keys(), reverse=True):
-                days.append({"day": day, "employees": grouped[year][month][day]})
-            months.append({"month": month, "days": days})
-        sorted_grouped.append({"year": year, "months": months})
+    context = {
+        "form": form,
+        "reports": reports,
+    }
+    return render(request, "core/upload_employees.html", context)
 
-    return render(
-        request,
-        "core/upload_employees.html",
-        {"form": form, "grouped": sorted_grouped},
-    )
+
+def report_detail(request, pk):
+    """عرض تفاصيل كشف استقدام محفوظ."""
+    report = RecruitmentReport.objects.get(pk=pk)
+    return render(request, "core/report_detail.html", {"report": report})
 
 
 # ---------------------------------------------------------------------------

--- a/templates/core/report_detail.html
+++ b/templates/core/report_detail.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load recruitment_extras %}
+{% block title %}تفاصيل كشف الاستقدام{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-6 text-center text-[#119383]">{{ report.filename }}</h1>
+<div class="overflow-x-auto">
+  <table class="min-w-full divide-y divide-gray-200 border">
+    <thead>
+      <tr>
+        {% for col in report.columns %}
+          <th class="px-2 py-1 border bg-gray-50 text-xs font-semibold text-gray-700">{{ col }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in report.rows %}
+      <tr>
+        {% for col in report.columns %}
+          <td class="px-2 py-1 border text-sm text-gray-900">{{ row|get_item:col }}</td>
+        {% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -1,56 +1,67 @@
 {% extends 'base.html' %}
-{% block title %}تحميل الموظفين{% endblock %}
-{% block content %}
-<h1 class="text-2xl font-bold mb-4">تحميل كشوف الموظفين</h1>
-<form method="post" enctype="multipart/form-data" class="mb-6 space-y-4">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">رفع</button>
-</form>
+{% load recruitment_extras %}
+{% block title %}أرشفة كشوفات الاستقدام{% endblock %}
 
-{% for year in grouped %}
-<details class="mb-4">
-  <summary class="cursor-pointer font-bold">{{ year.year }}</summary>
-  {% for month in year.months %}
-  <details class="ml-4 mb-3">
-    <summary class="cursor-pointer font-semibold">الشهر {{ month.month }}</summary>
-    {% for day in month.days %}
-    <details class="ml-8 mb-2">
-      <summary class="cursor-pointer">اليوم {{ day.day }}</summary>
-      <table class="min-w-full divide-y divide-gray-200 my-2">
-        <thead>
-          <tr>
-            <th class="px-2">الاسم</th>
-            <th class="px-2">الرقم الوظيفي</th>
-            <th class="px-2">التاريخ</th>
-            <th class="px-2">حرمين؟</th>
-            <th class="px-2">الدرجة النهائية</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for emp in day.employees %}
-          <tr>
-            <td class="px-2">{{ emp.name }}</td>
-            <td class="px-2">{{ emp.employee_number }}</td>
-            <td class="px-2">{{ emp.start_date }}</td>
-            <td class="px-2">{{ emp.is_haramain|yesno:"نعم,لا" }}</td>
-            <td class="px-2">
-              <form method="post" action="{% url 'core:set_final_score' emp.pk %}" class="flex space-x-1 items-center">
-                {% csrf_token %}
-                <input type="number" step="0.01" name="final_score" value="{{ emp.final_score|default_if_none:'' }}" class="border px-2 w-20 text-sm">
-                <button type="submit" class="px-2 text-green-600">حفظ</button>
-              </form>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </details>
+{% block content %}
+
+<h1 class="text-3xl font-bold mb-6 text-center text-[#119383]">رفع وأرشفة كشوف الاستقدام</h1>
+
+<!-- نموذج رفع كشف جديد -->
+<div class="flex justify-center my-6">
+  <form method="post" enctype="multipart/form-data" class="bg-white p-6 rounded-lg shadow-md w-full max-w-lg">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="px-6 py-2 bg-green-700 hover:bg-green-800 text-white rounded">رفع الكشف</button>
+  </form>
+</div>
+
+<!-- عرض الكشوفات المؤرشفة -->
+<div class="my-10">
+  <h2 class="text-xl font-bold mb-4 text-gray-700">الكشوفات المؤرشفة</h2>
+  {% if reports %}
+    {% for year, months in reports.items %}
+      <details class="mb-3">
+        <summary class="font-bold cursor-pointer text-lg text-[#099389]">سنة {{ year }}</summary>
+        {% for month, days in months.items %}
+          <details class="ml-4 mb-2">
+            <summary class="font-semibold cursor-pointer text-[#0c6672]">شهر {{ month }}</summary>
+            {% for day, files in days.items %}
+              <details class="ml-8 mb-2">
+                <summary class="cursor-pointer text-[#1e3459]">يوم {{ day }}</summary>
+                {% for file in files %}
+                  <details class="ml-12 mb-1">
+                    <summary class="cursor-pointer text-[#19786a]">{{ file.filename }}</summary>
+                    <div class="overflow-x-auto mt-2 mb-5">
+                      <table class="min-w-full divide-y divide-gray-200 border">
+                        <thead>
+                          <tr>
+                            {% for col in file.columns %}
+                              <th class="px-2 py-1 border bg-gray-50 text-xs font-semibold text-gray-700">{{ col }}</th>
+                            {% endfor %}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {% for row in file.rows %}
+                          <tr>
+                            {% for col in file.columns %}
+                              <td class="px-2 py-1 border text-sm text-gray-900">{{ row|get_item:col }}</td>
+                            {% endfor %}
+                          </tr>
+                          {% endfor %}
+                        </tbody>
+                      </table>
+                    </div>
+                  </details>
+                {% endfor %}
+              </details>
+            {% endfor %}
+          </details>
+        {% endfor %}
+      </details>
     {% endfor %}
-  </details>
-  {% endfor %}
-</details>
-{% empty %}
-<p>لا توجد بيانات</p>
-{% endfor %}
+  {% else %}
+    <div class="text-center text-gray-500">لا توجد كشوفات مؤرشفة بعد.</div>
+  {% endif %}
+</div>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `RecruitmentReport` model for storing raw excel data
- add form for uploading recruitment reports
- rebuild `upload_employees` view to save reports
- add detail page for reports
- register model in admin
- add helper template filter to read dict values
- update templates for hierarchical browsing
- add URL for report detail

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6855a23f23548332a2ff7aab004f35cb