### PR TITLE
Fix widget class rendering in recruitment upload form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -83,10 +83,20 @@ class UploadEmployeesForm(forms.Form):
 
 
 class RecruitmentReportForm(forms.Form):
-    file = forms.FileField(label="كشف الاستقدام (Excel)")
+    file = forms.FileField(
+        label="كشف الاستقدام (Excel)",
+        widget=forms.FileInput(
+            attrs={"class": "w-full border border-gray-300 rounded-md p-2"}
+        ),
+    )
     report_date = forms.DateField(
         label="تاريخ الكشف",
-        widget=forms.DateInput(attrs={"type": "date"}),
+        widget=forms.DateInput(
+            attrs={
+                "type": "date",
+                "class": "w-full border border-gray-300 rounded-md p-2",
+            }
+        ),
     )
 
 

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -13,11 +13,11 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
         {{ form.file.label_tag }}
-        {{ form.file.as_widget(attrs={'class': 'w-full border border-gray-300 rounded-md p-2'}) }}
+        {{ form.file }}
       </div>
       <div>
         {{ form.report_date.label_tag }}
-        {{ form.report_date.as_widget(attrs={'class': 'w-full border border-gray-300 rounded-md p-2'}) }}
+        {{ form.report_date }}
       </div>
     </div>
     <button type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg shadow">


### PR DESCRIPTION
## Summary
- style recruitment upload widgets in the form definition
- simplify the template markup for the upload form

## Testing
- `python manage.py test` *(fails: ImportError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855a68b0dd08332b91f7965609857f6