### PR TITLE
Add report type filtering and upload field

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -89,6 +89,15 @@ class RecruitmentReportForm(forms.Form):
             attrs={"class": "w-full border border-gray-300 rounded-md p-2"}
         ),
     )
+    HARAMAIN_CHOICES = [
+        ("true", "حرمين"),
+        ("false", "غير حرمين"),
+    ]
+    is_haramain = forms.ChoiceField(
+        choices=HARAMAIN_CHOICES,
+        label="نوع الكشف",
+        widget=forms.Select(attrs={"class": "w-full border border-gray-300 rounded-md p-2"}),
+    )
     report_date = forms.DateField(
         label="تاريخ الكشف",
         widget=forms.DateInput(

--- a/core/migrations/0015_recruitmentreport_is_haramain.py
+++ b/core/migrations/0015_recruitmentreport_is_haramain.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0014_update_recruitmentemployee"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="recruitmentreport",
+            name="is_haramain",
+            field=models.BooleanField(default=False, verbose_name="حرمين"),
+        ),
+        migrations.AlterUniqueTogether(
+            name="recruitmentreport",
+            unique_together={("filename", "report_date", "is_haramain")},
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -222,11 +222,12 @@ class RecruitmentReport(models.Model):
         verbose_name="تم الرفع بواسطة",
     )
     report_date = models.DateField("تاريخ الكشف")
+    is_haramain = models.BooleanField("حرمين", default=False)
     columns = models.JSONField("الأعمدة")
     rows = models.JSONField("الصفوف")
 
     class Meta:
-        unique_together = ("filename", "report_date")
+        unique_together = ("filename", "report_date", "is_haramain")
         verbose_name = "كشف استقدام"
         verbose_name_plural = "كشوف الاستقدام"
 

--- a/core/views.py
+++ b/core/views.py
@@ -257,9 +257,12 @@ def upload_employees(request):
         if form.is_valid():
             excel = form.cleaned_data["file"]
             report_date = form.cleaned_data["report_date"]
+            is_haramain = form.cleaned_data["is_haramain"] == "true"
 
             if RecruitmentReport.objects.filter(
-                filename=excel.name, report_date=report_date
+                filename=excel.name,
+                report_date=report_date,
+                is_haramain=is_haramain,
             ).exists():
                 messages.error(request, "تم رفع هذا الكشف مسبقاً")
                 return redirect("core:upload_employees")
@@ -272,6 +275,7 @@ def upload_employees(request):
                 filename=excel.name,
                 uploaded_by=request.user if request.user.is_authenticated else None,
                 report_date=report_date,
+                is_haramain=is_haramain,
                 columns=columns,
                 rows=rows,
             )
@@ -280,15 +284,20 @@ def upload_employees(request):
     else:
         form = RecruitmentReportForm()
 
-    reports_qs = RecruitmentReport.objects.all().order_by("-report_date")
+    filter_type = request.GET.get("type")
+    reports_qs = RecruitmentReport.objects.all()
+    if filter_type in ["true", "false"]:
+        reports_qs = reports_qs.filter(is_haramain=(filter_type == "true"))
+    reports_qs = reports_qs.order_by("-report_date")
     reports = {}
     for rep in reports_qs:
         dt = rep.report_date
-        reports.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(rep)
+        reports.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, {}).setdefault(rep.is_haramain, []).append(rep)
 
     context = {
         "form": form,
         "reports": reports,
+        "filter_type": filter_type,
     }
     return render(request, "core/upload_employees.html", context)
 

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -8,9 +8,9 @@
 
 <!-- نموذج رفع كشف جديد -->
 <div class="flex items-center justify-center my-8">
-  <form method="post" enctype="multipart/form-data" class="bg-white border rounded-xl shadow-lg p-6 w-full max-w-xl space-y-4">
+  <form method="post" enctype="multipart/form-data" class="bg-white border rounded-xl shadow-lg p-6 w-full max-w-2xl space-y-4">
     {% csrf_token %}
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div>
         {{ form.file.label_tag }}
         {{ form.file }}
@@ -18,6 +18,10 @@
       <div>
         {{ form.report_date.label_tag }}
         {{ form.report_date }}
+      </div>
+      <div>
+        {{ form.is_haramain.label_tag }}
+        {{ form.is_haramain }}
       </div>
     </div>
     <button type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg shadow">
@@ -30,6 +34,15 @@
 <!-- عرض الكشوفات المؤرشفة -->
 <div class="my-10">
   <h2 class="text-xl font-bold mb-4 text-gray-700">الكشوفات المؤرشفة</h2>
+  <form method="get" class="mb-4 flex flex-wrap items-center gap-2">
+    <label for="type" class="font-semibold">نوع الكشف:</label>
+    <select name="type" id="type" class="border rounded p-1">
+      <option value="" {% if not filter_type %}selected{% endif %}>الكل</option>
+      <option value="true" {% if filter_type == 'true' %}selected{% endif %}>حرمين</option>
+      <option value="false" {% if filter_type == 'false' %}selected{% endif %}>غير حرمين</option>
+    </select>
+    <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">فلترة</button>
+  </form>
   {% if reports %}
     {% for year, months in reports.items %}
       <details class="mb-3">
@@ -43,38 +56,46 @@
               <i class="fa-regular fa-calendar-days"></i>
               شهر {{ month }}
             </summary>
-            {% for day, files in days.items %}
+            {% for day, types in days.items %}
               <details class="ml-8 mb-2">
                 <summary class="cursor-pointer text-blue-900 flex items-center gap-2">
                   <i class="fa-regular fa-calendar-day"></i>
                   يوم {{ day }}
                 </summary>
-                {% for file in files %}
+                {% for type, files in types.items %}
                   <details class="ml-12 mb-1">
                     <summary class="cursor-pointer text-[#19786a] flex items-center gap-2">
                       <i class="fa-regular fa-folder-open"></i>
-                      {{ file.filename }}
+                      {{ type|yesno:"حرمين,غير حرمين" }}
                     </summary>
-                    <div class="overflow-x-auto mt-2 mb-5 bg-white border rounded-lg shadow">
-                      <table class="min-w-full divide-y divide-gray-200 text-sm">
-                        <thead>
-                          <tr>
-                            {% for col in file.columns %}
-                              <th class="px-2 py-1 border bg-gray-50 text-xs font-semibold text-gray-700 whitespace-nowrap">{{ col }}</th>
-                            {% endfor %}
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {% for row in file.rows %}
-                          <tr class="odd:bg-gray-50">
-                            {% for col in file.columns %}
-                              <td class="px-2 py-1 border text-gray-900 whitespace-nowrap">{{ row|get_item:col }}</td>
-                            {% endfor %}
-                          </tr>
-                          {% endfor %}
-                        </tbody>
-                      </table>
-                    </div>
+                    {% for file in files %}
+                      <details class="ml-12 mb-1">
+                        <summary class="cursor-pointer text-[#19786a] flex items-center gap-2">
+                          <i class="fa-regular fa-folder-open"></i>
+                          {{ file.filename }}
+                        </summary>
+                        <div class="overflow-x-auto mt-2 mb-5 bg-white border rounded-lg shadow">
+                          <table class="min-w-full divide-y divide-gray-200 text-sm">
+                            <thead>
+                              <tr>
+                                {% for col in file.columns %}
+                                  <th class="px-2 py-1 border bg-gray-50 text-xs font-semibold text-gray-700 whitespace-nowrap">{{ col }}</th>
+                                {% endfor %}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {% for row in file.rows %}
+                              <tr class="odd:bg-gray-50">
+                                {% for col in file.columns %}
+                                  <td class="px-2 py-1 border text-gray-900 whitespace-nowrap">{{ row|get_item:col }}</td>
+                                {% endfor %}
+                              </tr>
+                              {% endfor %}
+                            </tbody>
+                          </table>
+                        </div>
+                      </details>
+                    {% endfor %}
                   </details>
                 {% endfor %}
               </details>
@@ -84,7 +105,7 @@
       </details>
     {% endfor %}
   {% else %}
-    <div class="text-center text-gray-500">لا توجد كشوفات مؤرشفة بعد.</div>
+    <div class="text-center text-gray-500">لا توجد كشوفات بهذا النوع.</div>
   {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary
- support distinguishing Haramayn vs Non-Haramayn reports
- filter recruitment report archive by report type
- store report type with uploaded reports
- improve upload form layout and report archive view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6855a8558cd48332af9d7f43d616e393