### PR TITLE
Improve recruitment upload UI

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -85,8 +85,11 @@ class UploadEmployeesForm(forms.Form):
 class RecruitmentReportForm(forms.Form):
     file = forms.FileField(
         label="كشف الاستقدام (Excel)",
-        widget=forms.FileInput(
-            attrs={"class": "w-full border border-gray-300 rounded-md p-2"}
+        widget=forms.ClearableFileInput(
+            attrs={
+                "class": "w-full border border-gray-300 rounded-md p-2",
+                "multiple": True,
+            }
         ),
     )
     HARAMAIN_CHOICES = [

--- a/core/urls.py
+++ b/core/urls.py
@@ -62,6 +62,8 @@ urlpatterns = [
     # استقدام الحديث
     path("recruitment/upload/", views.upload_employees, name="upload_employees"),
     path("recruitment/report/<int:pk>/", views.report_detail, name="report_detail"),
+    path("recruitment/report/<int:pk>/delete/", views.delete_report, name="delete_report"),
+    path("recruitment/report/<int:pk>/export/", views.export_report_excel, name="export_report"),
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
     path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),
     path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,6 @@
 # core/views.py
 from django.shortcuts import render, redirect
+from django.http import HttpResponse
 from django.contrib import messages
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
@@ -255,49 +256,84 @@ def upload_employees(request):
     if request.method == "POST":
         form = RecruitmentReportForm(request.POST, request.FILES)
         if form.is_valid():
-            excel = form.cleaned_data["file"]
             report_date = form.cleaned_data["report_date"]
             is_haramain = form.cleaned_data["is_haramain"] == "true"
+            files = request.FILES.getlist("file")
+            saved = 0
+            skipped = []
 
-            if RecruitmentReport.objects.filter(
-                filename=excel.name,
-                report_date=report_date,
-                is_haramain=is_haramain,
-            ).exists():
-                messages.error(request, "تم رفع هذا الكشف مسبقاً")
-                return redirect("core:upload_employees")
+            for excel in files:
+                if RecruitmentReport.objects.filter(
+                    filename=excel.name,
+                    report_date=report_date,
+                    is_haramain=is_haramain,
+                ).exists():
+                    skipped.append(excel.name)
+                    continue
 
-            df = pd.read_excel(excel)
-            columns = df.columns.tolist()
-            rows = df.fillna("").to_dict(orient="records")
+                df = pd.read_excel(excel)
+                columns = df.columns.tolist()
+                rows = df.fillna("").to_dict(orient="records")
 
-            RecruitmentReport.objects.create(
-                filename=excel.name,
-                uploaded_by=request.user if request.user.is_authenticated else None,
-                report_date=report_date,
-                is_haramain=is_haramain,
-                columns=columns,
-                rows=rows,
-            )
-            messages.success(request, "تم حفظ الكشف بنجاح")
+                RecruitmentReport.objects.create(
+                    filename=excel.name,
+                    uploaded_by=request.user if request.user.is_authenticated else None,
+                    report_date=report_date,
+                    is_haramain=is_haramain,
+                    columns=columns,
+                    rows=rows,
+                )
+                saved += 1
+
+            if saved:
+                messages.success(request, f"تم حفظ {saved} كشف بنجاح")
+            if skipped:
+                messages.error(
+                    request,
+                    "تم تخطي الكشوف المكررة: " + ", ".join(skipped),
+                )
             return redirect("core:upload_employees")
     else:
         form = RecruitmentReportForm()
 
     filter_type = request.GET.get("type")
+    year = request.GET.get("year")
+    month = request.GET.get("month")
+    search = request.GET.get("q")
+
     reports_qs = RecruitmentReport.objects.all()
     if filter_type in ["true", "false"]:
         reports_qs = reports_qs.filter(is_haramain=(filter_type == "true"))
+    if year:
+        reports_qs = reports_qs.filter(report_date__year=year)
+    if month:
+        reports_qs = reports_qs.filter(report_date__month=month)
+    if search:
+        reports_qs = reports_qs.filter(filename__icontains=search)
+
     reports_qs = reports_qs.order_by("-report_date")
     reports = {}
+    total_employees = 0
+    latest = reports_qs.first()
     for rep in reports_qs:
         dt = rep.report_date
+        total_employees += len(rep.rows)
         reports.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, {}).setdefault(rep.is_haramain, []).append(rep)
+
+    stats = {
+        "total_reports": reports_qs.count(),
+        "total_employees": total_employees,
+        "latest": latest,
+    }
 
     context = {
         "form": form,
         "reports": reports,
         "filter_type": filter_type,
+        "stats": stats,
+        "year": year,
+        "month": month,
+        "search": search,
     }
     return render(request, "core/upload_employees.html", context)
 
@@ -306,6 +342,26 @@ def report_detail(request, pk):
     """عرض تفاصيل كشف استقدام محفوظ."""
     report = RecruitmentReport.objects.get(pk=pk)
     return render(request, "core/report_detail.html", {"report": report})
+
+
+@require_POST
+def delete_report(request, pk):
+    """حذف كشف استقدام."""
+    report = RecruitmentReport.objects.filter(pk=pk).first()
+    if report:
+        report.delete()
+        messages.success(request, "تم حذف الكشف")
+    return redirect("core:upload_employees")
+
+
+def export_report_excel(request, pk):
+    """تصدير كشف إلى ملف Excel."""
+    report = RecruitmentReport.objects.get(pk=pk)
+    df = pd.DataFrame(report.rows, columns=report.columns)
+    response = HttpResponse(content_type="application/vnd.ms-excel")
+    response["Content-Disposition"] = f"attachment; filename={report.filename}"
+    df.to_excel(response, index=False)
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -24,3 +24,12 @@ body{
   color:#991b1b;
 }
 
+@keyframes fadeIn {
+  from {opacity: 0; transform: translateY(20px);}
+  to {opacity: 1; transform: translateY(0);}
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.6s ease-out;
+}
+

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -8,41 +8,61 @@
 
 <!-- نموذج رفع كشف جديد -->
 <div class="flex items-center justify-center my-8">
-  <form method="post" enctype="multipart/form-data" class="bg-white border rounded-xl shadow-lg p-6 w-full max-w-2xl space-y-4">
-    {% csrf_token %}
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+  <div class="max-w-xl mx-auto bg-white rounded-2xl shadow-lg p-8 border border-green-200 w-full animate-fade-in">
+    <h2 class="text-xl font-bold mb-2 text-green-700 flex items-center gap-2"><i class="fa-solid fa-upload"></i> رفع كشف استقدام جديد</h2>
+    <form method="post" enctype="multipart/form-data" class="space-y-5">
+      {% csrf_token %}
       <div>
-        {{ form.file.label_tag }}
+        <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-file-excel"></i> {{ form.file.label }}</label>
         {{ form.file }}
+        {{ form.file.errors }}
       </div>
       <div>
-        {{ form.report_date.label_tag }}
+        <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-calendar-days"></i> {{ form.report_date.label }}</label>
         {{ form.report_date }}
+        {{ form.report_date.errors }}
       </div>
       <div>
-        {{ form.is_haramain.label_tag }}
+        <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-layer-group"></i> {{ form.is_haramain.label }}</label>
         {{ form.is_haramain }}
+        {{ form.is_haramain.errors }}
       </div>
-    </div>
-    <button type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg shadow">
-      <i class="fa-solid fa-upload"></i>
-      <span>رفع الكشف</span>
-    </button>
-  </form>
+      <button class="w-full py-2 rounded-lg bg-green-700 hover:bg-green-800 text-white font-bold flex items-center justify-center gap-2">
+        <i class="fa-solid fa-cloud-arrow-up"></i>
+        رفع الكشف
+      </button>
+    </form>
+  </div>
 </div>
 
 <!-- عرض الكشوفات المؤرشفة -->
 <div class="my-10">
   <h2 class="text-xl font-bold mb-4 text-gray-700">الكشوفات المؤرشفة</h2>
-  <form method="get" class="mb-4 flex flex-wrap items-center gap-2">
-    <label for="type" class="font-semibold">نوع الكشف:</label>
-    <select name="type" id="type" class="border rounded p-1">
-      <option value="" {% if not filter_type %}selected{% endif %}>الكل</option>
-      <option value="true" {% if filter_type == 'true' %}selected{% endif %}>حرمين</option>
-      <option value="false" {% if filter_type == 'false' %}selected{% endif %}>غير حرمين</option>
-    </select>
-    <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">فلترة</button>
-  </form>
+  <div class="mb-4 flex flex-wrap items-center gap-2 text-sm bg-white p-3 rounded shadow">
+    <form method="get" class="flex flex-wrap items-center gap-2 w-full">
+      <label for="q" class="font-semibold">بحث:</label>
+      <input type="text" name="q" id="q" value="{{ search }}" class="border rounded p-1" placeholder="اسم الملف">
+      <label for="year" class="font-semibold">السنة:</label>
+      <input type="number" name="year" id="year" value="{{ year }}" class="border rounded p-1 w-20">
+      <label for="month" class="font-semibold">الشهر:</label>
+      <input type="number" name="month" id="month" value="{{ month }}" class="border rounded p-1 w-16">
+      <label for="type" class="font-semibold">نوع الكشف:</label>
+      <select name="type" id="type" class="border rounded p-1">
+        <option value="" {% if not filter_type %}selected{% endif %}>الكل</option>
+        <option value="true" {% if filter_type == 'true' %}selected{% endif %}>حرمين</option>
+        <option value="false" {% if filter_type == 'false' %}selected{% endif %}>غير حرمين</option>
+      </select>
+      <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">بحث</button>
+    </form>
+    <div class="flex items-center gap-4 mt-2 w-full">
+      <div>إجمالي الكشوف: <span class="font-bold">{{ stats.total_reports }}</span></div>
+      <div>إجمالي الأفراد: <span class="font-bold">{{ stats.total_employees }}</span></div>
+      {% if stats.latest %}
+      <div>آخر كشف: <span class="font-bold">{{ stats.latest.filename }}</span> بتاريخ {{ stats.latest.report_date }}</div>
+      {% endif %}
+      <button type="button" onclick="window.print()" class="ml-auto px-3 py-1 bg-gray-200 rounded hover:bg-gray-300">طباعة</button>
+    </div>
+  </div>
   {% if reports %}
     {% for year, months in reports.items %}
       <details class="mb-3">
@@ -73,6 +93,11 @@
                         <summary class="cursor-pointer text-[#19786a] flex items-center gap-2">
                           <i class="fa-regular fa-folder-open"></i>
                           {{ file.filename }}
+                          <a href="{% url 'core:export_report' file.pk %}" class="text-blue-600 hover:underline text-xs mr-2" title="تصدير"><i class="fa-solid fa-file-export"></i></a>
+                          <form action="{% url 'core:delete_report' file.pk %}" method="post" class="inline">
+                            {% csrf_token %}
+                            <button type="submit" class="text-red-600 text-xs" onclick="return confirm('حذف الكشف؟');"><i class="fa-solid fa-trash"></i></button>
+                          </form>
                         </summary>
                         <div class="overflow-x-auto mt-2 mb-5 bg-white border rounded-lg shadow">
                           <table class="min-w-full divide-y divide-gray-200 text-sm">


### PR DESCRIPTION
## Summary
- support uploading multiple recruitment reports at once
- add stats, search and filtering for archived reports
- allow deleting or exporting a report
- redesign upload form with icons and animation
- add small fade-in animation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855ac344b488332a5ce15f25cb87de9