### PR TITLE
Improve evaluation form layout

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -132,4 +132,44 @@ class EmployeeEvaluationForm(forms.ModelForm):
             "evaluation_photo",
             "orientation_photo",
         ]
+        widgets = {
+            "appearance_score": forms.NumberInput(
+                attrs={
+                    "class": "w-full border-2 border-gray-300 rounded px-3 py-2",
+                    "placeholder": "0-10",
+                }
+            ),
+            "experience_score": forms.NumberInput(
+                attrs={
+                    "class": "w-full border-2 border-gray-300 rounded px-3 py-2",
+                    "placeholder": "0-10",
+                }
+            ),
+            "skills_score": forms.NumberInput(
+                attrs={
+                    "class": "w-full border-2 border-gray-300 rounded px-3 py-2",
+                    "placeholder": "0-10",
+                }
+            ),
+            "notes": forms.Textarea(
+                attrs={
+                    "class": "w-full border-2 border-gray-300 rounded px-3 py-2",
+                    "rows": 3,
+                    "placeholder": "اكتب أي ملاحظات...",
+                }
+            ),
+            "evaluation_photo": forms.ClearableFileInput(
+                attrs={"class": "w-full"}
+            ),
+            "orientation_photo": forms.ClearableFileInput(
+                attrs={"class": "w-full"}
+            ),
+        }
+        help_texts = {
+            "appearance_score": "قيّم المظهر من 0 إلى 10.",
+            "experience_score": "قيّم الخبرة من 0 إلى 10.",
+            "skills_score": "قيّم المهارات من 0 إلى 10.",
+            "evaluation_photo": "ارفع صورة أثناء التقييم إن وجدت.",
+            "orientation_photo": "ارفع صورة من المحاضرة التعريفية إن وجدت.",
+        }
 

--- a/templates/core/evaluate_employee.html
+++ b/templates/core/evaluate_employee.html
@@ -1,10 +1,57 @@
 {% extends 'base.html' %}
 {% block title %}تقييم الموظف{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">تقييم {{ employee.name }}</h1>
-<form method="post" enctype="multipart/form-data" class="space-y-4">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">حفظ</button>
-</form>
+<h1 class="text-2xl font-bold text-center mb-6">تقييم {{ employee.name }}</h1>
+
+<div class="max-w-md mx-auto bg-white rounded-xl shadow p-6">
+  <form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+
+    <div>
+      {{ form.appearance_score.label_tag }}
+      {{ form.appearance_score }}
+      <p class="text-sm text-gray-500">{{ form.appearance_score.help_text }}</p>
+      {{ form.appearance_score.errors }}
+    </div>
+
+    <div>
+      {{ form.experience_score.label_tag }}
+      {{ form.experience_score }}
+      <p class="text-sm text-gray-500">{{ form.experience_score.help_text }}</p>
+      {{ form.experience_score.errors }}
+    </div>
+
+    <div>
+      {{ form.skills_score.label_tag }}
+      {{ form.skills_score }}
+      <p class="text-sm text-gray-500">{{ form.skills_score.help_text }}</p>
+      {{ form.skills_score.errors }}
+    </div>
+
+    <div>
+      {{ form.notes.label_tag }}
+      {{ form.notes }}
+      <p class="text-sm text-gray-500">{{ form.notes.help_text }}</p>
+      {{ form.notes.errors }}
+    </div>
+
+    <div>
+      {{ form.evaluation_photo.label_tag }}
+      {{ form.evaluation_photo }}
+      <p class="text-sm text-gray-500">{{ form.evaluation_photo.help_text }}</p>
+      {{ form.evaluation_photo.errors }}
+    </div>
+
+    <div>
+      {{ form.orientation_photo.label_tag }}
+      {{ form.orientation_photo }}
+      <p class="text-sm text-gray-500">{{ form.orientation_photo.help_text }}</p>
+      {{ form.orientation_photo.errors }}
+    </div>
+
+    <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-semibold py-2 rounded">
+      حفظ
+    </button>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add form widgets and help texts for evaluation form
- style evaluation form with card layout and help text

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6855b910bc14833284d841fd87ba3fdd