### PR TITLE
Enhance upload help text and keyboard navigation

### DIFF
--- a/templates/core/navbar.html
+++ b/templates/core/navbar.html
@@ -11,7 +11,7 @@
   </ul>
 
   {% if request.user.is_authenticated %}
-  <div class="user-menu" onclick="toggleDropdown()">
+  <div class="user-menu" onclick="toggleDropdown()" tabindex="0" aria-label="قائمة المستخدم" onkeydown="if(event.key==='Enter'||event.key===' ') toggleDropdown();">
     <span><i class="fa-solid fa-user"></i> مرحباً {{ learner.first_name_ar }} {{ learner.last_name_ar }} <i class="fa-solid fa-caret-down ml-1"></i></span>
     <ul id="dropdownMenu" class="dropdown hidden">
       <li>

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -13,31 +13,31 @@
     <p class="desc">مرحبًا بك في بوابتك لتسهيل عمليات الاستقدام والتقييم والتوثيق… اختر الخدمة المطلوبة للبدء 👇</p>
   </div>
   <div class="recruitment-grid">
-    <a href="{% url 'core:upload_employees' %}" class="recruitment-card" title="رفع كشف الموظفين">
+    <a href="{% url 'core:upload_employees' %}" class="recruitment-card" title="رفع كشف الموظفين" aria-label="رفع كشف الموظفين">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-users"></i></div></div>
       <div class="recruitment-name">رفع كشف الموظفين</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'forms' %}" class="recruitment-card" title="إصدار نماذج التقييم">
+    <a href="{% url 'core:recruitment_step' 'forms' %}" class="recruitment-card" title="إصدار نماذج التقييم" aria-label="إصدار نماذج التقييم">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-file-alt"></i></div></div>
       <div class="recruitment-name">إصدار نماذج التقييم</div>
     </a>
-    <a href="{% url 'core:input_evaluation_results' %}" class="recruitment-card" title="إدخال نتائج المتقدمين">
+    <a href="{% url 'core:input_evaluation_results' %}" class="recruitment-card" title="إدخال نتائج المتقدمين" aria-label="إدخال نتائج المتقدمين">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-keyboard"></i></div></div>
       <div class="recruitment-name">إدخال نتائج التقييم</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'update_db' %}" class="recruitment-card" title="تحديث قاعدة البيانات">
+    <a href="{% url 'core:recruitment_step' 'update_db' %}" class="recruitment-card" title="تحديث قاعدة البيانات" aria-label="تحديث قاعدة البيانات">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-database"></i></div></div>
       <div class="recruitment-name">تحديث قاعدة البيانات</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'upload_results' %}" class="recruitment-card" title="رفع الملفات المعتمدة">
+    <a href="{% url 'core:recruitment_step' 'upload_results' %}" class="recruitment-card" title="رفع الملفات المعتمدة" aria-label="رفع الملفات المعتمدة">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-upload"></i></div></div>
       <div class="recruitment-name">رفع نتائج التقييم</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'upload_photos' %}" class="recruitment-card" title="رفع صور التقييم">
+    <a href="{% url 'core:recruitment_step' 'upload_photos' %}" class="recruitment-card" title="رفع صور التقييم" aria-label="رفع صور التقييم">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-camera"></i></div></div>
       <div class="recruitment-name">رفع صور التقييم والمحاضرة التعريفية</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'attendance' %}" class="recruitment-card" title="إصدار كشف الحضور">
+    <a href="{% url 'core:recruitment_step' 'attendance' %}" class="recruitment-card" title="إصدار كشف الحضور" aria-label="إصدار كشف الحضور">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-list"></i></div></div>
       <div class="recruitment-name">إصدار كشف الحضور والغياب</div>
     </a>
@@ -128,6 +128,8 @@
 .recruitment-card:nth-child(5){animation-delay:0.5s;}
 .recruitment-card:nth-child(6){animation-delay:0.6s;}
 .recruitment-card:nth-child(7){animation-delay:0.7s;}
+.recruitment-card:focus { outline: 2px dashed #119383; outline-offset: 4px; }
+
 .recruitment-card:hover {
   box-shadow: 0 12px 32px rgba(7,44,82,0.25), 0 0 16px rgba(0,156,88,0.45);
   transform: translateY(-6px) scale(1.05);
@@ -135,6 +137,7 @@
   border-color: var(--accent);
   color: #fff;
 }
+
 .recruitment-card::after {
   content: '';
   position: absolute;

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -16,7 +16,6 @@
           <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-file-excel"></i> {{ form.file.label }}</label>
           {{ form.file }}
           {{ form.file.errors }}
-          <small class="text-gray-500">الملفات المسموحة: xlsx, xls (الحد الأقصى: 5MB)</small>
         </div>
         <div>
           <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-calendar-days"></i> {{ form.report_date.label }}</label>
@@ -28,10 +27,11 @@
         {{ form.is_haramain }}
         {{ form.is_haramain.errors }}
       </div>
-      <button type="submit" class="flex items-center gap-2 px-6 py-2 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg shadow mx-auto mt-4">
+      <button type="submit" class="flex items-center gap-2 px-6 py-2 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg shadow mx-auto mt-4" aria-label="رفع الكشف">
         <i class="fa-solid fa-upload"></i>
         <span>رفع الكشف</span>
       </button>
+      <p class="text-center text-gray-500 text-sm mt-2">الملفات المسموحة: xlsx, xls (الحد الأقصى: 5MB)</p>
       <p class="text-center text-gray-500 text-sm mt-2">
         بعد اختيار الملف وتحديد النوع والتاريخ، اضغط على زر رفع لإضافة الكشف للأرشيف
       </p>
@@ -64,7 +64,7 @@
       {% if stats.latest %}
       <div>آخر كشف: <span class="font-bold">{{ stats.latest.filename }}</span> بتاريخ {{ stats.latest.report_date }}</div>
       {% endif %}
-      <button type="button" onclick="window.print()" class="ml-auto px-3 py-1 bg-gray-200 rounded hover:bg-gray-300">طباعة</button>
+      <button type="button" onclick="window.print()" class="ml-auto px-3 py-1 bg-gray-200 rounded hover:bg-gray-300" aria-label="طباعة">طباعة</button>
     </div>
   </div>
   {% if reports %}
@@ -97,10 +97,10 @@
                         <summary class="cursor-pointer text-[#19786a] flex items-center gap-2">
                           <i class="fa-regular fa-folder-open"></i>
                           {{ file.filename }}
-                          <a href="{% url 'core:export_report' file.pk %}" class="text-blue-600 hover:underline text-xs mr-2" title="تصدير"><i class="fa-solid fa-file-export"></i></a>
+                          <a href="{% url 'core:export_report' file.pk %}" class="text-blue-600 hover:underline text-xs mr-2" title="تصدير" aria-label="تصدير الملف"><i class="fa-solid fa-file-export"></i></a>
                           <form action="{% url 'core:delete_report' file.pk %}" method="post" class="inline">
                             {% csrf_token %}
-                            <button type="submit" class="text-red-600 text-xs" onclick="return confirm('حذف الكشف؟');"><i class="fa-solid fa-trash"></i></button>
+                            <button type="submit" class="text-red-600 text-xs" aria-label="حذف الكشف" onclick="return confirm('حذف الكشف؟');"><i class="fa-solid fa-trash"></i></button>
                           </form>
                         </summary>
                         <div class="overflow-x-auto mt-2 mb-5 bg-white border rounded-lg shadow">


### PR DESCRIPTION
## Summary
- clarify allowed file types/size below the upload button
- add keyboard accessibility for the user menu
- provide aria-labels for dashboard cards and action icons
- highlight recruitment cards on keyboard focus

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b92c66508332887caa78ee0b0f0c