### PR TITLE
Fix missing styles for upload button

### DIFF
--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -29,7 +29,7 @@
         {{ form.is_haramain }}
         {{ form.is_haramain.errors }}
       </div>
-      <button type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-700 hover:bg-green-800 text-white font-semibold rounded-lg shadow mt-6 w-1/3 mx-auto">
+      <button type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg shadow mt-6 w-full sm:w-1/3 mx-auto">
         <i class="fa-solid fa-upload"></i>
         <span>رفع الكشف</span>
       </button>


### PR DESCRIPTION
## Summary
- ensure the button for uploading employees report uses classes that exist in output.css

## Testing
- `python manage.py test` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855c516ad1c83328d44107424ca1550