### PR TITLE
Enhance upload employees UX

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -138,14 +138,20 @@ class RecruitmentReportForm(forms.Form):
     is_haramain = forms.ChoiceField(
         choices=HARAMAIN_CHOICES,
         label="نوع الكشف",
-        widget=forms.Select(attrs={"class": "w-full border border-gray-300 rounded-md p-2"}),
+        widget=forms.Select(
+            attrs={
+                "class": "w-full border border-gray-300 rounded-md p-2 pl-10",
+                "placeholder": "اختر نوع الكشف",
+            }
+        ),
     )
     report_date = forms.DateField(
         label="تاريخ الكشف",
         widget=forms.DateInput(
             attrs={
                 "type": "date",
-                "class": "w-full border border-gray-300 rounded-md p-2",
+                "class": "w-full border border-gray-300 rounded-md p-2 pl-10",
+                "placeholder": "أدخل تاريخ الكشف",
             }
         ),
     )

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -37,3 +37,28 @@ body{
   direction: ltr;
 }
 
+.drop-area {
+  border: 2px dashed #a7f3d0;
+  background: #f0fdf4;
+  padding: 1rem;
+  text-align: center;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s;
+}
+
+.drop-area.dragover {
+  background: #dcfce7;
+}
+
+.input-icon {
+  position: relative;
+}
+.input-icon i {
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #9ca3af;
+  pointer-events: none;
+}
+

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -4,32 +4,38 @@
 
 {% block content %}
 
-<h1 class="text-3xl font-bold mb-6 text-center text-[#119383]">رفع وأرشفة كشوف الاستقدام</h1>
+<h1 class="text-4xl font-bold mb-8 text-center text-[#119383]">رفع وأرشفة كشوف الاستقدام</h1>
 
 <!-- نموذج رفع كشف جديد -->
   <div class="flex items-center justify-center my-8">
-    <div class="max-w-xl mx-auto bg-white rounded-2xl shadow-lg p-8 border border-green-200 w-full animate-fade-in text-right">
-      <h2 class="text-xl font-bold mb-2 text-green-700 flex items-center gap-2"><i class="fa-solid fa-upload"></i> رفع كشف استقدام جديد</h2>
-      <div id="uploadMessages"></div>
-      <form id="uploadForm" method="post" enctype="multipart/form-data" class="space-y-5">
+    <div class="max-w-xl mx-auto bg-gradient-to-br from-green-50 via-white to-green-50 rounded-2xl shadow-lg p-8 border border-green-200 w-full animate-fade-in text-right">
+      <h2 class="text-xl font-bold mb-4 text-green-700 flex items-center gap-2"><i class="fa-solid fa-upload"></i> رفع كشف استقدام جديد</h2>
+      <div id="uploadMessages" class="mt-4"></div>
+      <form id="uploadForm" method="post" enctype="multipart/form-data" class="space-y-6">
         {% csrf_token %}
-        <div>
+        <div class="space-y-2">
           <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-file-excel"></i> {{ form.file.label }}</label>
-          {{ form.file }}
+          <div id="dropArea" class="drop-area">
+            {{ form.file }}
+            <p class="text-gray-500 text-sm mt-2">اسحب الملف هنا أو اضغط لاختياره</p>
+          </div>
+          <div id="fileNames" class="text-gray-600 text-sm"></div>
           {{ form.file.errors }}
           <small class="text-gray-500">الملفات المسموحة: xlsx, xls (الحد الأقصى: 5MB)</small>
         </div>
-        <div>
+        <div class="input-icon">
           <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-calendar-days"></i> {{ form.report_date.label }}</label>
+          <i class="fa-regular fa-calendar"></i>
           {{ form.report_date }}
           {{ form.report_date.errors }}
       </div>
-      <div>
+      <div class="input-icon">
         <label class="block mb-1 font-semibold text-gray-700"><i class="fa-solid fa-layer-group"></i> {{ form.is_haramain.label }}</label>
+        <i class="fa-solid fa-layer-group"></i>
         {{ form.is_haramain }}
         {{ form.is_haramain.errors }}
       </div>
-      <button type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg shadow mt-6 w-full sm:w-1/3 mx-auto">
+      <button id="submitBtn" type="submit" class="flex items-center justify-center gap-2 px-6 py-2 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg shadow mt-6 w-full sm:w-1/3 mx-auto disabled:opacity-50" disabled>
         <i class="fa-solid fa-upload"></i>
         <span>رفع الكشف</span>
       </button>
@@ -152,17 +158,41 @@
   const progressBar      = document.getElementById('uploadProgressBar');
   const progressText     = document.getElementById('uploadProgressText');
   const messagesBox      = document.getElementById('uploadMessages');
+  const fileInput        = document.getElementById('id_file');
+  const dropArea         = document.getElementById('dropArea');
+  const fileNames        = document.getElementById('fileNames');
+  const submitBtn        = document.getElementById('submitBtn');
+
+  function updateFileNames() {
+    const names = Array.from(fileInput.files).map(f => f.name).join(', ');
+    fileNames.textContent = names;
+    checkValid();
+  }
+
+  function checkValid() {
+    if (!submitBtn) return;
+    const hasFiles = fileInput.files && fileInput.files.length > 0;
+    const dateFilled = form.report_date.value;
+    const typeFilled = form.is_haramain.value;
+    submitBtn.disabled = !(hasFiles && dateFilled && typeFilled);
+  }
 
   function showMessage(text, type) {
     messagesBox.innerHTML = '';
     if (!text) return;
     const div = document.createElement('div');
-    div.className = `mb-4 px-4 py-2 rounded-md shadow ${type}`;
-    div.textContent = text;
+    div.className = `mb-4 px-4 py-2 rounded-md shadow flex items-center gap-2 ${type}`;
+    const icon = document.createElement('i');
+    icon.className = type === 'success' ? 'fa-solid fa-circle-check' : 'fa-solid fa-circle-xmark';
+    div.appendChild(icon);
+    const span = document.createElement('span');
+    span.textContent = text;
+    div.appendChild(span);
     messagesBox.appendChild(div);
   }
 
   if (form) {
+    updateFileNames();
     form.addEventListener('submit', function (e) {
       e.preventDefault();
       const xhr = new XMLHttpRequest();
@@ -186,7 +216,7 @@
           try { data = JSON.parse(xhr.responseText); } catch (err) {}
           if (data.success) { showMessage(data.success, 'success'); }
           if (data.error) { showMessage(data.error, 'error'); }
-          if (data.success && !data.error) { form.reset(); }
+          if (data.success && !data.error) { form.reset(); updateFileNames(); }
         } else {
           let msg = 'حدث خطأ أثناء الرفع';
           try { msg = JSON.parse(xhr.responseText).error || msg; } catch (err) {}
@@ -201,6 +231,26 @@
       };
       xhr.send(formData);
     });
+
+    fileInput.addEventListener('change', updateFileNames);
+    form.report_date.addEventListener('change', checkValid);
+    form.is_haramain.addEventListener('change', checkValid);
+
+    if (dropArea) {
+      ['dragenter', 'dragover'].forEach(evt => dropArea.addEventListener(evt, e => {
+        e.preventDefault();
+        dropArea.classList.add('dragover');
+      }));
+      ['dragleave', 'drop'].forEach(evt => dropArea.addEventListener(evt, e => {
+        e.preventDefault();
+        dropArea.classList.remove('dragover');
+      }));
+      dropArea.addEventListener('drop', e => {
+        fileInput.files = e.dataTransfer.files;
+        updateFileNames();
+      });
+      dropArea.addEventListener('click', () => fileInput.click());
+    }
   }
 </script>
 


### PR DESCRIPTION
## Summary
- add placeholders and extra padding for recruitment upload form
- improve styles for success messages and file input drag/drop
- support drag & drop upload with progress feedback
- disable submit until fields filled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856ddf68b688332b6e998134a20e036