### PR TITLE
Show uploaded recruitment reports with AJAX table

### DIFF
--- a/core/migrations/0018_recruitmentreport_file_size.py
+++ b/core/migrations/0018_recruitmentreport_file_size.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0017_merge_20250620_2141'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='recruitmentreport',
+            name='file_size',
+            field=models.PositiveIntegerField(default=0, verbose_name='حجم الملف (بايت)'),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -222,6 +222,7 @@ class RecruitmentReport(models.Model):
         verbose_name="تم الرفع بواسطة",
     )
     report_date = models.DateField("تاريخ الكشف")
+    file_size = models.PositiveIntegerField("حجم الملف (بايت)", default=0)
     is_haramain = models.BooleanField("حرمين", default=False)
     columns = models.JSONField("الأعمدة")
     rows = models.JSONField("الصفوف")

--- a/core/templatetags/recruitment_extras.py
+++ b/core/templatetags/recruitment_extras.py
@@ -8,3 +8,16 @@ def get_item(data, key):
     if isinstance(data, dict):
         return data.get(key, "")
     return ""
+
+
+@register.filter
+def file_icon(filename: str) -> str:
+    """Return Font Awesome class based on file extension."""
+    if not filename:
+        return "fa-file"
+    ext = filename.split(".")[-1].lower()
+    if ext in ["xls", "xlsx"]:
+        return "fa-file-excel"
+    if ext == "pdf":
+        return "fa-file-pdf"
+    return "fa-file"

--- a/core/urls.py
+++ b/core/urls.py
@@ -64,6 +64,7 @@ urlpatterns = [
     path("recruitment/report/<int:pk>/", views.report_detail, name="report_detail"),
     path("recruitment/report/<int:pk>/delete/", views.delete_report, name="delete_report"),
     path("recruitment/report/<int:pk>/export/", views.export_report_excel, name="export_report"),
+    path("recruitment/reports/json/", views.reports_json, name="reports_json"),
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
     path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),
     path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),

--- a/core/views.py
+++ b/core/views.py
@@ -12,6 +12,7 @@ from django.utils.encoding import force_bytes, force_str
 from django.urls import reverse
 from django.core.mail import send_mail
 from django.contrib.sites.shortcuts import get_current_site
+from django.template.defaultfilters import filesizeformat
 import re
 from openpyxl import load_workbook
 import pandas as pd
@@ -281,6 +282,7 @@ def upload_employees(request):
                     filename=excel.name,
                     uploaded_by=request.user if request.user.is_authenticated else None,
                     report_date=report_date,
+                    file_size=excel.size,
                     is_haramain=is_haramain,
                     columns=columns,
                     rows=rows,
@@ -338,9 +340,12 @@ def upload_employees(request):
         "latest": latest,
     }
 
+    reports_list = reports_qs
+
     context = {
         "form": form,
         "reports": reports,
+        "reports_list": reports_list,
         "filter_type": filter_type,
         "stats": stats,
         "year": year,
@@ -526,6 +531,24 @@ def tree_filter_results(request):
             "filename": r.filename,
             "report_date": r.report_date.strftime("%Y-%m-%d"),
             "is_haramain": r.is_haramain,
+        }
+        for r in qs
+    ]
+    return JsonResponse(data, safe=False)
+
+
+def reports_json(request):
+    """Return all recruitment reports as JSON for dynamic tables."""
+    qs = RecruitmentReport.objects.all().order_by("-uploaded_at")
+    data = [
+        {
+            "id": r.id,
+            "filename": r.filename,
+            "uploaded_at": r.uploaded_at.strftime("%Y-%m-%d %H:%M"),
+            "file_size": r.file_size,
+            "file_size_formatted": filesizeformat(r.file_size),
+            "is_haramain": r.is_haramain,
+            "report_date": r.report_date.strftime("%Y-%m-%d"),
         }
         for r in qs
     ]

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -60,8 +60,54 @@
 </div>
 
 <!-- عرض الكشوفات المؤرشفة -->
-<div class="my-10">
-  {{ block.super }}
+<div class="my-10 max-w-4xl mx-auto">
+  <h2 class="text-xl font-bold mb-4 text-green-700 flex items-center gap-2">
+    <i class="fa-solid fa-file-archive"></i> الكشوف المرفوعة
+  </h2>
+  <div class="overflow-x-auto bg-white rounded shadow">
+    <table class="min-w-full text-sm text-center">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-3 py-2">اسم الملف</th>
+          <th class="px-3 py-2">تاريخ الرفع</th>
+          <th class="px-3 py-2">الحجم</th>
+          <th class="px-3 py-2">نوع الكشف</th>
+          <th class="px-3 py-2">العمليات</th>
+        </tr>
+      </thead>
+      <tbody id="reportsTableBody">
+        {% for rep in reports_list %}
+        <tr class="odd:bg-gray-50">
+          <td class="px-3 py-2 flex items-center gap-2">
+            <i class="fa-solid {{ rep.filename|file_icon }}"></i>
+            {{ rep.filename }}
+          </td>
+          <td class="px-3 py-2">{{ rep.uploaded_at|date:"Y-m-d H:i" }}</td>
+          <td class="px-3 py-2">{{ rep.file_size|filesizeformat }}</td>
+          <td class="px-3 py-2">{{ rep.is_haramain|yesno:"حرمين,غير حرمين" }}</td>
+          <td class="px-3 py-2 space-x-1 space-x-reverse">
+            <a href="{% url 'core:export_report' rep.id %}" class="text-green-600 hover:text-green-800" title="تحميل">
+              <i class="fa-solid fa-download"></i>
+            </a>
+            <a href="{% url 'core:report_detail' rep.id %}" target="_blank" class="text-blue-600 hover:text-blue-800" title="معاينة">
+              <i class="fa-solid fa-eye"></i>
+            </a>
+            <form method="post" action="{% url 'core:delete_report' rep.id %}" class="inline">
+              {% csrf_token %}
+              <button type="submit" class="text-red-600 hover:text-red-800" title="حذف" onclick="return confirm('هل أنت متأكد من الحذف؟')">
+                <i class="fa-solid fa-trash"></i>
+              </button>
+            </form>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="5" class="p-4 text-gray-500">لا توجد ملفات مرفوعة بعد.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
 
 <script>
@@ -71,6 +117,46 @@
   const progressBar      = document.getElementById('uploadProgressBar');
   const progressText     = document.getElementById('uploadProgressText');
   const messagesBox      = document.getElementById('uploadMessages');
+  const tableBody        = document.getElementById('reportsTableBody');
+  const csrfToken        = form.querySelector('[name=csrfmiddlewaretoken]').value;
+
+  function getIcon(filename){
+    const ext = filename.split('.').pop().toLowerCase();
+    if(['xls','xlsx'].includes(ext)) return 'fa-file-excel';
+    if(ext === 'pdf') return 'fa-file-pdf';
+    return 'fa-file';
+  }
+
+  function fetchReports(){
+    fetch('{% url "core:reports_json" %}')
+      .then(r => r.json())
+      .then(data => {
+        tableBody.innerHTML = '';
+        if(!data.length){
+          tableBody.innerHTML = '<tr><td colspan="5" class="p-4 text-gray-500">لا توجد ملفات مرفوعة بعد.</td></tr>';
+          return;
+        }
+        data.forEach(rep => {
+          const tr = document.createElement('tr');
+          tr.className = 'odd:bg-gray-50';
+          tr.innerHTML = `
+            <td class="px-3 py-2 flex items-center gap-2"><i class="fa-solid ${getIcon(rep.filename)}"></i> ${rep.filename}</td>
+            <td class="px-3 py-2">${rep.uploaded_at}</td>
+            <td class="px-3 py-2">${rep.file_size_formatted}</td>
+            <td class="px-3 py-2">${rep.is_haramain ? 'حرمين' : 'غير حرمين'}</td>
+            <td class="px-3 py-2 space-x-1 space-x-reverse">
+              <a href="/recruitment/report/${rep.id}/export/" class="text-green-600 hover:text-green-800" title="تحميل"><i class="fa-solid fa-download"></i></a>
+              <a href="/recruitment/report/${rep.id}/" target="_blank" class="text-blue-600 hover:text-blue-800" title="معاينة"><i class="fa-solid fa-eye"></i></a>
+              <form method="post" action="/recruitment/report/${rep.id}/delete/" class="inline">
+                <input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}">
+                <button type="submit" class="text-red-600 hover:text-red-800" title="حذف" onclick="return confirm('هل أنت متأكد من الحذف؟')"><i class="fa-solid fa-trash"></i></button>
+              </form>`;
+          tableBody.appendChild(tr);
+        });
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', fetchReports);
 
   function showMessage(text, type) {
     messagesBox.innerHTML = '';
@@ -105,7 +191,7 @@
           try { data = JSON.parse(xhr.responseText); } catch (err) {}
           if (data.success) { showMessage(data.success, 'success'); }
           if (data.error) { showMessage(data.error, 'error'); }
-          if (data.success && !data.error) { form.reset(); }
+          if (data.success && !data.error) { form.reset(); fetchReports(); }
         } else {
           let msg = 'حدث خطأ أثناء الرفع';
           try { msg = JSON.parse(xhr.responseText).error || msg; } catch (err) {}


### PR DESCRIPTION
## Summary
- store upload file size in `RecruitmentReport`
- expose icon helper for filenames
- allow listing reports as JSON
- display uploaded reports in `upload_employees` with Tailwind table and live updates
- add migration for new field

## Testing
- `pip install -r requirements.txt` *(fails: network access blocked)*
- `python manage.py makemigrations`


------
https://chatgpt.com/codex/tasks/task_e_6858129a52288332b918e7719043b88f