### PR TITLE
Improve recruitment reports table interactivity

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -70,3 +70,24 @@ input:focus, select:focus, textarea:focus {
 ::placeholder{
   color:#d1d5db;
 }
+/* Enhancements for recruitment table */
+#reportsTable tbody tr:hover{
+  background-color:#f0fdf4;
+}
+
+.action-btn{
+  font-size:1.2rem;
+  padding:0.25rem;
+  transition:transform 0.2s;
+  display:inline-block;
+}
+.action-btn:hover{
+  transform:scale(1.1);
+}
+
+.icon-haramain{
+  color:#16a34a;
+}
+.icon-not-haramain{
+  color:#9ca3af;
+}

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -95,23 +95,29 @@
       <tbody id="reportsTableBody">
         {% for rep in reports_list %}
         <tr class="odd:bg-gray-50">
-          <td class="px-3 py-2 flex items-center gap-2" title="{{ rep.filename }}">
+          <td class="px-3 py-2 flex items-center gap-2 truncate max-w-xs" title="{{ rep.filename }}">
             <i class="fa-solid {{ rep.filename|file_icon }}"></i>
             {{ rep.filename|truncate_middle:40 }}
           </td>
           <td class="px-3 py-2">{{ rep.uploaded_at|date:"Y-m-d H:i" }}</td>
           <td class="px-3 py-2">{{ rep.file_size|filesizeformat }}</td>
-          <td class="px-3 py-2">{{ rep.is_haramain|yesno:"حرمين,غير حرمين" }}</td>
+          <td class="px-3 py-2 text-lg">
+            {% if rep.is_haramain %}
+              <i class="fa-solid fa-circle-check icon-haramain" title="حرمين"></i>
+            {% else %}
+              <i class="fa-solid fa-circle-minus icon-not-haramain" title="غير حرمين"></i>
+            {% endif %}
+          </td>
           <td class="px-3 py-2 space-x-1 space-x-reverse">
-            <a href="{% url 'core:export_report' rep.id %}" class="text-green-600 hover:text-green-800" title="تحميل">
+            <a href="{% url 'core:export_report' rep.id %}" class="action-btn text-green-600 hover:text-green-800" title="تحميل">
               <i class="fa-solid fa-download"></i>
             </a>
-            <a href="{% url 'core:report_detail' rep.id %}" target="_blank" class="text-blue-600 hover:text-blue-800" title="معاينة">
+            <a href="{% url 'core:report_detail' rep.id %}" target="_blank" class="action-btn text-blue-600 hover:text-blue-800" title="معاينة">
               <i class="fa-solid fa-eye"></i>
             </a>
             <form method="post" action="{% url 'core:delete_report' rep.id %}" class="inline">
               {% csrf_token %}
-              <button type="submit" class="text-red-600 hover:text-red-800" title="حذف" onclick="return confirm('هل أنت متأكد من الحذف؟')">
+              <button type="submit" class="action-btn text-red-600 hover:text-red-800" title="حذف" onclick="return confirm('هل أنت متأكد من الحذف؟')">
                 <i class="fa-solid fa-trash"></i>
               </button>
             </form>
@@ -119,7 +125,10 @@
         </tr>
         {% empty %}
         <tr>
-          <td colspan="5" class="p-4 text-gray-500">لا توجد ملفات مرفوعة بعد.</td>
+          <td colspan="5" class="p-4 text-gray-500 text-center">
+            <i class="fa-solid fa-folder-open text-2xl text-gray-400"></i>
+            <span class="block mt-1">لا توجد نتائج – جرب فلترًا مختلفًا!</span>
+          </td>
         </tr>
         {% endfor %}
       </tbody>
@@ -166,23 +175,26 @@
       .then(data => {
         tableBody.innerHTML = '';
         if(!data.length){
-          tableBody.innerHTML = '<tr><td colspan="5" class="p-4 text-gray-500">لا توجد ملفات مرفوعة بعد.</td></tr>';
+          tableBody.innerHTML = `<tr><td colspan="5" class="p-4 text-gray-500">
+            <i class='fa-solid fa-folder-open text-2xl text-gray-400'></i>
+            <span class='block mt-1'>لا توجد نتائج – جرب فلترًا مختلفًا!</span>
+          </td></tr>`;
           return;
         }
         data.forEach(rep => {
           const tr = document.createElement('tr');
           tr.className = 'odd:bg-gray-50';
           tr.innerHTML = `
-            <td class="px-3 py-2 flex items-center gap-2" title="${rep.filename}"><i class="fa-solid ${getIcon(rep.filename)}"></i> ${rep.filename.length>40?rep.filename.slice(0,18)+'...'+rep.filename.slice(-18):rep.filename}</td>
+            <td class="px-3 py-2 flex items-center gap-2 truncate max-w-xs" title="${rep.filename}"><i class="fa-solid ${getIcon(rep.filename)}"></i> ${rep.filename.length>40?rep.filename.slice(0,18)+'...'+rep.filename.slice(-18):rep.filename}</td>
             <td class="px-3 py-2">${rep.uploaded_at}</td>
             <td class="px-3 py-2">${rep.file_size_formatted}</td>
-            <td class="px-3 py-2">${rep.is_haramain ? 'حرمين' : 'غير حرمين'}</td>
+            <td class="px-3 py-2 text-lg">${rep.is_haramain ? `<i class='fa-solid fa-circle-check icon-haramain' title='حرمين'></i>` : `<i class='fa-solid fa-circle-minus icon-not-haramain' title='غير حرمين'></i>`}</td>
             <td class="px-3 py-2 space-x-1 space-x-reverse">
-              <a href="/recruitment/report/${rep.id}/export/" class="text-green-600 hover:text-green-800" title="تحميل"><i class="fa-solid fa-download"></i></a>
-              <a href="/recruitment/report/${rep.id}/" target="_blank" class="text-blue-600 hover:text-blue-800" title="معاينة"><i class="fa-solid fa-eye"></i></a>
+              <a href="/recruitment/report/${rep.id}/export/" class="action-btn text-green-600 hover:text-green-800" title="تحميل"><i class="fa-solid fa-download"></i></a>
+              <a href="/recruitment/report/${rep.id}/" target="_blank" class="action-btn text-blue-600 hover:text-blue-800" title="معاينة"><i class="fa-solid fa-eye"></i></a>
               <form method="post" action="/recruitment/report/${rep.id}/delete/" class="inline">
                 <input type="hidden" name="csrfmiddlewaretoken" value="${csrfToken}">
-                <button type="submit" class="text-red-600 hover:text-red-800" title="حذف" onclick="return confirm('هل أنت متأكد من الحذف؟')"><i class="fa-solid fa-trash"></i></button>
+                <button type="submit" class="action-btn text-red-600 hover:text-red-800" title="حذف" onclick="return confirm('هل أنت متأكد من الحذف؟')"><i class="fa-solid fa-trash"></i></button>
               </form>`;
           tableBody.appendChild(tr);
         });


### PR DESCRIPTION
## Summary
- style table rows and action icons
- color-code Haramain status icons and enlarge action buttons
- show nicer message when no search results
- apply same behaviour to dynamic table rows

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68593aa4b88c8332815a5569610314c4