### PR TITLE
Fix import for RecruitmentReport

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -44,8 +44,14 @@ class MultipleFileField(forms.FileField):
 
         return cleaned
 
-from .models import Learner, Nationality, Sector
-from .models import RecruitmentEmployee, EmployeeEvaluation
+from .models import (
+    Learner,
+    Nationality,
+    Sector,
+    RecruitmentEmployee,
+    EmployeeEvaluation,
+    RecruitmentReport,
+)
 
 
 # ـــــــ الخطوة 1: المعلومات الشخصية ـــــــ #


### PR DESCRIPTION
## Summary
- import `RecruitmentReport` in `core/forms.py` so `RecruitmentReportEditForm` can access the model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6859463afc288332911c3facbf3e76eb