### PR TITLE
Implement actions and auto-hide for upload page

### DIFF
--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -121,7 +121,20 @@
               <td class="px-3 py-2">{{ rep.uploaded_at|date:"Y-m-d H:i" }}</td>
               <td class="px-3 py-2">{{ rep.file_size|filesizeformat }}</td>
               <td class="px-3 py-2">{{ rep.is_haramain|yesno:"حرمين,غير حرمين" }}</td>
-              <td class="px-3 py-2">أزرار العمليات</td>
+              <td class="px-3 py-2 space-x-2 space-x-reverse">
+                <a href="{% url 'core:report_detail' rep.id %}" class="action-btn tooltip text-blue-600" data-tooltip="معاينة">
+                  <i class="fa-solid fa-eye"></i>
+                </a>
+                <a href="{% url 'core:export_report' rep.id %}" class="action-btn tooltip text-green-600" data-tooltip="تحميل">
+                  <i class="fa-solid fa-download"></i>
+                </a>
+                <form method="post" action="{% url 'core:delete_report' rep.id %}" class="inline">
+                  {% csrf_token %}
+                  <button type="submit" class="action-btn tooltip text-red-600" data-tooltip="حذف">
+                    <i class="fa-solid fa-trash"></i>
+                  </button>
+                </form>
+              </td>
             </tr>
           {% empty %}
             <tr>
@@ -162,6 +175,11 @@
         fileInput.dispatchEvent(new Event('change', { bubbles: true }));
       }
     });
+
+    const successMsg = document.querySelector('.success');
+    if (successMsg) {
+      setTimeout(() => successMsg.remove(), 4000);
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- show preview, download and delete buttons in the recruitment reports table
- automatically hide success message after uploading

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685eae2dc9c483329e2e63a316a66f48