### PR TITLE
Improve project logging, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,25 @@ Failing to run migrations can lead to errors such as
 
 Ensure `DJANGO_SECRET_KEY` is set to a unique value in production to avoid using
 the default key from `settings.py`.
+
+## Local Setup
+
+1. Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Install and build Tailwind CSS assets (requires `npm`):
+
+```bash
+npm install
+npm run build:css &
+```
+
+3. Apply database migrations and start the development server:
+
+```bash
+python manage.py migrate
+python manage.py runserver
+```

--- a/config/settings.py
+++ b/config/settings.py
@@ -160,3 +160,13 @@ if DEBUG:
 # الحقل الافتراضي
 # ---------------------------------------------------------------------------
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# ---------------------------------------------------------------------------
+# إعدادات تسجيل الأحداث (Logging)
+# ---------------------------------------------------------------------------
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "root": {"handlers": ["console"], "level": "INFO"},
+}

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from django.db import IntegrityError
+from django.utils import timezone
+import datetime
 
 from .models import (
     Learner,
@@ -83,4 +85,45 @@ class LearnerModelTest(TestCase):
         learner = self._create_learner()
         self.assertEqual(learner.nationality, self.nationality)
         self.assertEqual(learner.sector, self.sector)
+
+
+class RecruitmentReportModelTest(TestCase):
+    """اختبارات نموذج كشف الاستقدام."""
+
+    def test_unique_together_constraint(self):
+        """يجب منع تكرار الملف لنفس التاريخ ونوع الكشف."""
+        from .models import RecruitmentReport
+
+        dt = datetime.date(2024, 1, 1)
+        RecruitmentReport.objects.create(
+            filename="rep.xlsx",
+            report_date=dt,
+            file_size=1,
+            is_haramain=False,
+            columns=["col"],
+            rows=[{"col": "x"}],
+        )
+        with self.assertRaises(IntegrityError):
+            RecruitmentReport.objects.create(
+                filename="rep.xlsx",
+                report_date=dt,
+                file_size=2,
+                is_haramain=False,
+                columns=["col"],
+                rows=[{"col": "y"}],
+            )
+
+    def test_str_representation(self):
+        from .models import RecruitmentReport
+
+        dt = datetime.date(2024, 1, 2)
+        rep = RecruitmentReport.objects.create(
+            filename="file.xlsx",
+            report_date=dt,
+            file_size=1,
+            is_haramain=True,
+            columns=["c"],
+            rows=[{"c": 1}],
+        )
+        self.assertEqual(str(rep), f"file.xlsx - {dt}")
 

--- a/core/views.py
+++ b/core/views.py
@@ -21,6 +21,10 @@ import datetime
 from django.views.decorators.http import require_POST
 import os
 import calendar
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 from .models import (
     Learner,
@@ -54,8 +58,8 @@ def home(request):
 # ---------------------------------------------------------------------------
 def recruitment_dashboard(request):
     """الواجهة الرئيسية لخطوات تقييم موظفي الاستقدام."""
-    print("Rendering template: core/recruitment_dashboard.html")
-    print("Template absolute path:", os.path.abspath(__file__))
+    logger.debug("Rendering recruitment dashboard")
+    logger.debug("Template absolute path: %s", os.path.abspath(__file__))
     return render(request, "core/recruitment_dashboard.html")
 
 
@@ -279,7 +283,8 @@ def upload_employees(request):
 
                 try:
                     df = pd.read_excel(excel)
-                except Exception as e:  # pragma: no cover - just logging
+                except (ValueError, OSError) as e:  # pragma: no cover - just logging
+                    logger.error("Failed reading %s: %s", excel.name, e)
                     errors.append(f"{excel.name}: {e}")
                     continue
 


### PR DESCRIPTION
## Summary
- add logger usage and handle Excel errors more cleanly
- configure Django logging
- extend README with local setup details
- add model tests for RecruitmentReport

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685eb52994c48332bf8d50066f5cae05