### PR TITLE
Switch to Decimal scores

### DIFF
--- a/core/migrations/0019_recruitmentemployee_decimal_scores.py
+++ b/core/migrations/0019_recruitmentemployee_decimal_scores.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0018_recruitmentreport_file_size'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='recruitmentemployee',
+            name='evaluation',
+            field=models.DecimalField(max_digits=5, decimal_places=2, null=True, blank=True, verbose_name='Evaluation'),
+        ),
+        migrations.AlterField(
+            model_name='recruitmentemployee',
+            name='final_score',
+            field=models.DecimalField(max_digits=5, decimal_places=2, null=True, blank=True, verbose_name='الدرجة النهائية'),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -147,7 +147,9 @@ class RecruitmentEmployee(models.Model):
     )
 
     # تقييم ونتائج
-    evaluation = models.FloatField("Evaluation", null=True, blank=True)
+    evaluation = models.DecimalField(
+        "Evaluation", max_digits=5, decimal_places=2, null=True, blank=True
+    )
     result = models.CharField("Result", max_length=100, blank=True, null=True)
     result_expectations = models.CharField(
         "Result Expectations", max_length=100, blank=True, null=True
@@ -157,7 +159,9 @@ class RecruitmentEmployee(models.Model):
     start_date = models.DateField("تاريخ المباشرة", null=True, blank=True)
     is_haramain = models.BooleanField("حرمين", default=False)
     created_at = models.DateTimeField(auto_now_add=True)
-    final_score = models.FloatField("الدرجة النهائية", null=True, blank=True)
+    final_score = models.DecimalField(
+        "الدرجة النهائية", max_digits=5, decimal_places=2, null=True, blank=True
+    )
 
     class Meta:
         verbose_name = "موظف استقدام"

--- a/core/views.py
+++ b/core/views.py
@@ -22,6 +22,7 @@ from django.views.decorators.http import require_POST
 import os
 import calendar
 import logging
+from decimal import Decimal
 
 
 logger = logging.getLogger(__name__)
@@ -440,8 +441,8 @@ def set_final_score(request, pk):
     employee = RecruitmentEmployee.objects.get(pk=pk)
     score = request.POST.get("final_score")
     try:
-        employee.final_score = float(score)
-    except (TypeError, ValueError):
+        employee.final_score = Decimal(score)
+    except (TypeError, ValueError, ArithmeticError):
         pass
     else:
         employee.save()
@@ -477,9 +478,9 @@ def input_evaluation_results(request):
             score = request.POST.get(f"score_{emp.id}")
             if score:
                 try:
-                    emp.final_score = float(score)
+                    emp.final_score = Decimal(score)
                     emp.save()
-                except ValueError:
+                except (ValueError, ArithmeticError):
                     pass
         messages.success(request, "تم حفظ الدرجات")
         return redirect(f"{reverse('core:input_evaluation_results')}?year={year}&month={month}&day={day}")


### PR DESCRIPTION
## Summary
- use `DecimalField` for `evaluation` and `final_score`
- update recruitment views to handle decimals
- add a migration for the new fields

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68613bc743c0833282af7f104fbad9cd