### PR TITLE
Add index to employee number

### DIFF
--- a/core/migrations/0020_recruitmentemployee_employee_number_index.py
+++ b/core/migrations/0020_recruitmentemployee_employee_number_index.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0019_recruitmentemployee_decimal_scores'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='recruitmentemployee',
+            name='employee_number',
+            field=models.CharField(max_length=50, verbose_name='الرقم الوظيفي', db_index=True),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -132,7 +132,9 @@ class RecruitmentEmployee(models.Model):
 
     # ترتيب الحقول بحسب الكشف الورقي
     serial = models.PositiveIntegerField("التسلسل", null=True, blank=True)
-    employee_number = models.CharField("الرقم الوظيفي", max_length=50)
+    employee_number = models.CharField(
+        "الرقم الوظيفي", max_length=50, db_index=True
+    )
     name = models.CharField("الاسم عربي", max_length=100)
     name_en = models.CharField(
         "الاسم انجليزي", max_length=100, blank=True, null=True


### PR DESCRIPTION
## Summary
- add a database index for the `RecruitmentEmployee.employee_number` field
- create migration for the new index

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68613e52f3308332be938bc785d08be6