### PR TITLE
Add grade columns and report links

### DIFF
--- a/core/templatetags/recruitment_extras.py
+++ b/core/templatetags/recruitment_extras.py
@@ -36,3 +36,21 @@ def truncate_middle(value: str, arg: int = 30) -> str:
         return value
     half = max(1, (length - 3) // 2)
     return f"{value[:half]}...{value[-half:]}"
+
+
+@register.filter
+def grade_symbol(score):
+    """Return a letter grade based on numeric score."""
+    try:
+        score = float(score)
+    except (TypeError, ValueError):
+        return ""
+    if score >= 90:
+        return "A"
+    if score >= 80:
+        return "B"
+    if score >= 70:
+        return "C"
+    if score >= 60:
+        return "D"
+    return "F"

--- a/core/views.py
+++ b/core/views.py
@@ -497,6 +497,11 @@ def input_evaluation_results(request):
     months = sorted(grouped.get(int(year), {}).keys(), reverse=True) if year and year.isdigit() else []
     days = sorted(grouped.get(int(year), {}).get(int(month), {}).keys(), reverse=True) if year and month and year.isdigit() and month.isdigit() else []
 
+    reports = []
+    if year and month and day and year.isdigit() and month.isdigit() and day.isdigit():
+        date_obj = datetime.date(int(year), int(month), int(day))
+        reports = RecruitmentReport.objects.filter(report_date=date_obj)
+
     context = {
         "years": years,
         "months": months,
@@ -505,6 +510,7 @@ def input_evaluation_results(request):
         "selected_month": month,
         "selected_day": day,
         "employees": selected,
+        "reports": reports,
     }
     return render(request, "core/input_results.html", context)
 

--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -23,6 +23,18 @@
   </select>
   <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">عرض</button>
 </form>
+{% if reports %}
+<div class="mb-4">
+  <span class="font-semibold">الملفات المتاحة:</span>
+  <ul class="list-disc list-inside">
+    {% for rep in reports %}
+    <li>
+      <a href="{% url 'core:report_detail' rep.id %}" class="text-blue-600 underline">{{ rep.filename }}</a>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
 {% if employees %}
 <form method="post">
   {% csrf_token %}
@@ -41,7 +53,9 @@
         <th class="px-2">المهنة</th>
         <th class="px-2">اسم الكفيل</th>
         <th class="px-2">Evaluation</th>
-        <th class="px-2">Result</th>
+        <th class="px-2">الدرجة</th>
+        <th class="px-2">رمز الدرجة</th>
+        <th class="px-2">النتيجة</th>
         <th class="px-2">Result Expectations</th>
       </tr>
     </thead>
@@ -60,6 +74,8 @@
           <input type="number" step="0.01" name="score_{{ emp.id }}" value="{{ emp.final_score|default_if_none:'' }}" class="border px-2 w-20 text-sm">
         </td>
         <td class="px-2">{{ emp.final_score }}</td>
+        <td class="px-2">{{ emp.final_score|grade_symbol }}</td>
+        <td class="px-2">{{ emp.result }}</td>
         <td class="px-2">{{ emp.result_expectations }}</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- show recruitment reports for selected date in results input view
- display grade, grade symbol and result on the input results table
- add `grade_symbol` template filter for converting numeric score to a letter

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68616d7cf3fc83329c875f877d6a0123