### PR TITLE
Fix missing filter load

### DIFF
--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load recruitment_extras %}
 {% block title %}إدخال نتائج التقييم{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">إدخال نتائج التقييم</h1>


### PR DESCRIPTION
## Summary
- load recruitment_extras in input_results template

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68616ebf4aac83328f255d0bc97fe9fb