### PR TITLE
Fix missing filter load

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -451,12 +451,12 @@ def set_final_score(request, pk):
 # ---------------------------------------------------------------------------
 def input_evaluation_results(request):
     """إدخال الدرجات لعدد من الموظفين دفعة واحدة."""
-    employees = RecruitmentEmployee.objects.all().order_by("created_at")
+    reports_all = RecruitmentReport.objects.all()
 
-    grouped = {}
-    for emp in employees:
-        dt = timezone.localtime(emp.created_at).date()
-        grouped.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(emp)
+    report_dates = {}
+    for rep in reports_all:
+        dt = rep.report_date
+        report_dates.setdefault(dt.year, {}).setdefault(dt.month, set()).add(dt.day)
 
     year = request.GET.get("year")
     month = request.GET.get("month")
@@ -471,7 +471,10 @@ def input_evaluation_results(request):
             y = int(year)
             m = int(month)
             d = int(day)
-            selected = grouped.get(y, {}).get(m, {}).get(d, [])
+            date_obj = datetime.date(y, m, d)
+            selected = list(
+                RecruitmentEmployee.objects.filter(created_at__date=date_obj).order_by("created_at")
+            )
         except (TypeError, ValueError):
             selected = []
         for emp in selected:
@@ -489,13 +492,24 @@ def input_evaluation_results(request):
             y = int(year)
             m = int(month)
             d = int(day)
-            selected = grouped.get(y, {}).get(m, {}).get(d, [])
+            date_obj = datetime.date(y, m, d)
+            selected = list(
+                RecruitmentEmployee.objects.filter(created_at__date=date_obj).order_by("created_at")
+            )
         except (TypeError, ValueError):
             selected = []
 
-    years = sorted(grouped.keys(), reverse=True)
-    months = sorted(grouped.get(int(year), {}).keys(), reverse=True) if year and year.isdigit() else []
-    days = sorted(grouped.get(int(year), {}).get(int(month), {}).keys(), reverse=True) if year and month and year.isdigit() and month.isdigit() else []
+    years = sorted(report_dates.keys(), reverse=True)
+    months = (
+        sorted(report_dates.get(int(year), {}).keys(), reverse=True)
+        if year and year.isdigit()
+        else []
+    )
+    days = (
+        sorted(report_dates.get(int(year), {}).get(int(month), []), reverse=True)
+        if year and month and year.isdigit() and month.isdigit()
+        else []
+    )
 
     reports = []
     if year and month and day and year.isdigit() and month.isdigit() and day.isdigit():

--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -1,21 +1,22 @@
 {% extends 'base.html' %}
+{% load recruitment_extras %}
 {% block title %}إدخال نتائج التقييم{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">إدخال نتائج التقييم</h1>
 <form method="get" class="flex space-x-2 mb-4">
-  <select name="year" class="border px-2 py-1">
+  <select name="year" class="border px-2 py-1" onchange="this.form.submit()">
     <option value="">السنة...</option>
     {% for y in years %}
     <option value="{{ y }}" {% if y|stringformat:'s' == selected_year %}selected{% endif %}>{{ y }}</option>
     {% endfor %}
   </select>
-  <select name="month" class="border px-2 py-1">
+  <select name="month" class="border px-2 py-1" onchange="this.form.submit()">
     <option value="">الشهر...</option>
     {% for m in months %}
     <option value="{{ m }}" {% if m|stringformat:'s' == selected_month %}selected{% endif %}>{{ m }}</option>
     {% endfor %}
   </select>
-  <select name="day" class="border px-2 py-1">
+  <select name="day" class="border px-2 py-1" onchange="this.form.submit()">
     <option value="">اليوم...</option>
     {% for d in days %}
     <option value="{{ d }}" {% if d|stringformat:'s' == selected_day %}selected{% endif %}>{{ d }}</option>
@@ -23,6 +24,9 @@
   </select>
   <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">عرض</button>
 </form>
+{% if not years %}
+<p class="mb-4 text-red-600">لا توجد بيانات متاحة. الرجاء رفع كشف الموظفين أولاً.</p>
+{% endif %}
 {% if reports %}
 <div class="mb-4">
   <span class="font-semibold">الملفات المتاحة:</span>


### PR DESCRIPTION
## Summary
- load recruitment_extras in input_results template
- auto-submit date selectors to reveal available options
- warn user when there is no employee data
- pull report dates for input_results

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68616ebf4aac83328f255d0bc97fe9fb