### PR TITLE
Fix input form to update employee results

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -172,6 +172,12 @@ class RecruitmentEmployee(models.Model):
     def __str__(self) -> str:
         return self.name
 
+    @property
+    def last_evaluation_date(self):
+        """Return date of the most recent evaluation if available."""
+        evaluation = self.evaluations.order_by("-evaluated_at").first()
+        return evaluation.evaluated_at.date() if evaluation else None
+
 
 class EmployeeEvaluation(models.Model):
     """تقييم موظف الاستقدام بعد المحاضرة التعريفية والتقييم العملي."""

--- a/core/views.py
+++ b/core/views.py
@@ -451,12 +451,12 @@ def set_final_score(request, pk):
 # ---------------------------------------------------------------------------
 def input_evaluation_results(request):
     """إدخال الدرجات لعدد من الموظفين دفعة واحدة."""
-    employees = RecruitmentEmployee.objects.all().order_by("created_at")
+    reports_all = RecruitmentReport.objects.all()
 
-    grouped = {}
-    for emp in employees:
-        dt = timezone.localtime(emp.created_at).date()
-        grouped.setdefault(dt.year, {}).setdefault(dt.month, {}).setdefault(dt.day, []).append(emp)
+    report_dates = {}
+    for rep in reports_all:
+        dt = rep.report_date
+        report_dates.setdefault(dt.year, {}).setdefault(dt.month, set()).add(dt.day)
 
     year = request.GET.get("year")
     month = request.GET.get("month")
@@ -471,17 +471,27 @@ def input_evaluation_results(request):
             y = int(year)
             m = int(month)
             d = int(day)
-            selected = grouped.get(y, {}).get(m, {}).get(d, [])
+            date_obj = datetime.date(y, m, d)
+            selected = list(
+                RecruitmentEmployee.objects.filter(created_at__date=date_obj).order_by("created_at")
+            )
         except (TypeError, ValueError):
             selected = []
         for emp in selected:
             score = request.POST.get(f"score_{emp.id}")
+            result_val = request.POST.get(f"result_{emp.id}")
+            changed = False
             if score:
                 try:
                     emp.final_score = Decimal(score)
-                    emp.save()
+                    changed = True
                 except (ValueError, ArithmeticError):
                     pass
+            if result_val is not None:
+                emp.result = result_val
+                changed = True
+            if changed:
+                emp.save()
         messages.success(request, "تم حفظ الدرجات")
         return redirect(f"{reverse('core:input_evaluation_results')}?year={year}&month={month}&day={day}")
     else:
@@ -489,13 +499,24 @@ def input_evaluation_results(request):
             y = int(year)
             m = int(month)
             d = int(day)
-            selected = grouped.get(y, {}).get(m, {}).get(d, [])
+            date_obj = datetime.date(y, m, d)
+            selected = list(
+                RecruitmentEmployee.objects.filter(created_at__date=date_obj).order_by("created_at")
+            )
         except (TypeError, ValueError):
             selected = []
 
-    years = sorted(grouped.keys(), reverse=True)
-    months = sorted(grouped.get(int(year), {}).keys(), reverse=True) if year and year.isdigit() else []
-    days = sorted(grouped.get(int(year), {}).get(int(month), {}).keys(), reverse=True) if year and month and year.isdigit() and month.isdigit() else []
+    years = sorted(report_dates.keys(), reverse=True)
+    months = (
+        sorted(report_dates.get(int(year), {}).keys(), reverse=True)
+        if year and year.isdigit()
+        else []
+    )
+    days = (
+        sorted(report_dates.get(int(year), {}).get(int(month), []), reverse=True)
+        if year and month and year.isdigit() and month.isdigit()
+        else []
+    )
 
     reports = []
     if year and month and day and year.isdigit() and month.isdigit() and day.isdigit():

--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -1,21 +1,22 @@
 {% extends 'base.html' %}
+{% load recruitment_extras %}
 {% block title %}إدخال نتائج التقييم{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-bold mb-4">إدخال نتائج التقييم</h1>
 <form method="get" class="flex space-x-2 mb-4">
-  <select name="year" class="border px-2 py-1">
+  <select name="year" class="border px-2 py-1" onchange="this.form.submit()">
     <option value="">السنة...</option>
     {% for y in years %}
     <option value="{{ y }}" {% if y|stringformat:'s' == selected_year %}selected{% endif %}>{{ y }}</option>
     {% endfor %}
   </select>
-  <select name="month" class="border px-2 py-1">
+  <select name="month" class="border px-2 py-1" onchange="this.form.submit()">
     <option value="">الشهر...</option>
     {% for m in months %}
     <option value="{{ m }}" {% if m|stringformat:'s' == selected_month %}selected{% endif %}>{{ m }}</option>
     {% endfor %}
   </select>
-  <select name="day" class="border px-2 py-1">
+  <select name="day" class="border px-2 py-1" onchange="this.form.submit()">
     <option value="">اليوم...</option>
     {% for d in days %}
     <option value="{{ d }}" {% if d|stringformat:'s' == selected_day %}selected{% endif %}>{{ d }}</option>
@@ -23,6 +24,9 @@
   </select>
   <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded">عرض</button>
 </form>
+{% if not years %}
+<p class="mb-4 text-red-600">لا توجد بيانات متاحة. الرجاء رفع كشف الموظفين أولاً.</p>
+{% endif %}
 {% if reports %}
 <div class="mb-4">
   <span class="font-semibold">الملفات المتاحة:</span>
@@ -52,7 +56,7 @@
         <th class="px-2">الجنسية</th>
         <th class="px-2">المهنة</th>
         <th class="px-2">اسم الكفيل</th>
-        <th class="px-2">Evaluation</th>
+        <th class="px-2">تاريخ التقييم</th>
         <th class="px-2">الدرجة</th>
         <th class="px-2">رمز الدرجة</th>
         <th class="px-2">النتيجة</th>
@@ -70,12 +74,14 @@
         <td class="px-2">{{ emp.nationality }}</td>
         <td class="px-2">{{ emp.official_job }}</td>
         <td class="px-2">{{ emp.sponsor_name }}</td>
+        <td class="px-2">{{ emp.last_evaluation_date }}</td>
         <td class="px-2">
           <input type="number" step="0.01" name="score_{{ emp.id }}" value="{{ emp.final_score|default_if_none:'' }}" class="border px-2 w-20 text-sm">
         </td>
-        <td class="px-2">{{ emp.final_score }}</td>
         <td class="px-2">{{ emp.final_score|grade_symbol }}</td>
-        <td class="px-2">{{ emp.result }}</td>
+        <td class="px-2">
+          <input type="text" name="result_{{ emp.id }}" value="{{ emp.result|default_if_none:'' }}" class="border px-2 w-32 text-sm">
+        </td>
         <td class="px-2">{{ emp.result_expectations }}</td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- expose last_evaluation_date on employees
- allow setting result text when saving scores
- display evaluation date and editable grade/result columns on results page

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68616ebf4aac83328f255d0bc97fe9fb