### PR TITLE
Add mul template filter

### DIFF
--- a/core/templatetags/recruitment_extras.py
+++ b/core/templatetags/recruitment_extras.py
@@ -54,3 +54,15 @@ def grade_symbol(score):
     if score >= 60:
         return "D"
     return "F"
+
+
+# ------------------------------------------------
+# General multiplication filter
+# ------------------------------------------------
+@register.filter
+def mul(value, arg):
+    """Return the product of ``value`` and ``arg`` for template usage."""
+    try:
+        return int(value) * int(arg)
+    except (TypeError, ValueError):
+        return ""


### PR DESCRIPTION
## Summary
- add `mul` filter to compute product of two arguments
- keep `__init__.py` so `templatetags` is a package

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68626d43e1108332a410c4d0b66a61dc