### PR TITLE
Fix date selector loop in template

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -480,18 +480,38 @@ def input_evaluation_results(request):
         except Exception:
             selected = []
 
+    years = sorted(dates.keys(), reverse=True)
+    months = (
+        sorted(dates.get(int(year), {}).keys(), reverse=True)
+        if year and year.isdigit()
+        else []
+    )
+    days = (
+        sorted(dates.get(int(year), {}).get(int(month), []), reverse=True)
+        if year and month and year.isdigit() and month.isdigit()
+        else []
+    )
+
     context = {
-        "years": sorted(dates.keys(), reverse=True),
-        "months": sorted(dates.get(int(year), {}).keys(), reverse=True) if year and year.isdigit() else [],
-        "days": sorted(dates.get(int(year), {}).get(int(month), []), reverse=True)
-                if year and month and year.isdigit() and month.isdigit() else [],
-        "selected_year":  year,
+        "years": years,
+        "months": months,
+        "days": days,
+        "selected_year": year,
         "selected_month": month,
-        "selected_day":   day,
-        "employees":      selected,
+        "selected_day": day,
+        "employees": selected,
         "reports": RecruitmentReport.objects.filter(
             report_date=datetime.date(int(year), int(month), int(day))
-        ) if (year and month and day and year.isdigit() and month.isdigit() and day.isdigit()) else [],
+        )
+        if (
+            year and month and day and year.isdigit() and month.isdigit() and day.isdigit()
+        )
+        else [],
+        "date_selectors": [
+            ("year", years, year),
+            ("month", months, month),
+            ("day", days, day),
+        ],
     }
     return render(request, "core/input_results.html", context)
 

--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -21,10 +21,7 @@
 
 {# ---------- شريط اختيار التاريخ ---------- #}
 <form method="get" class="flex flex-wrap justify-center gap-2 mb-6">
-  {% for name, items, selected in
-        ('year', years, selected_year),
-        ('month', months, selected_month),
-        ('day', days, selected_day) %}
+  {% for name, items, selected in date_selectors %}
     <select name="{{ name }}" class="border rounded-lg px-3 py-2 bg-white shadow-sm
                                      focus:outline-none focus:ring-2 focus:ring-blue-500"
             onchange="this.form.submit()">


### PR DESCRIPTION
## Summary
- simplify building date selectors in input_evaluation_results view
- iterate over new `date_selectors` list in template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686275a0fd5c8332a72c49862494d36c