### PR TITLE
Fix name cell wrapping in input results

### DIFF
--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -77,7 +77,7 @@
         <tr data-emp="{{ emp.employee_number }}">
           <td class="px-2">{{ forloop.counter }}</td>
           <td class="px-2 font-mono">{{ emp.employee_number }}</td>
-          <td class="px-2">{{ emp.name }}</td>
+          <td class="px-2 whitespace-nowrap">{{ emp.name }}</td>
 
           <td class="px-2">
             <input name="score_{{ emp.id }}" class="border rounded px-2 py-1 w-24


### PR DESCRIPTION
## Summary
- adjust employee name column to prevent wrapping

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862773450c08332b85d2bf50ddecde7