### PR TITLE
Fix name cell wrapping

### DIFF
--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -77,7 +77,7 @@
         <tr data-emp="{{ emp.employee_number }}">
           <td class="px-2">{{ forloop.counter }}</td>
           <td class="px-2 font-mono">{{ emp.employee_number }}</td>
-          <td class="px-2 whitespace-nowrap">{{ emp.name }}</td>
+          <td class="px-2 whitespace-nowrap" style="white-space: nowrap;">{{ emp.name }}</td>
 
           <td class="px-2">
             <input name="score_{{ emp.id }}" class="border rounded px-2 py-1 w-24


### PR DESCRIPTION
## Summary
- ensure employee name cell does not wrap to multiple lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686278a085e08332ab8f4ae98a280344