### PR TITLE
Fix evaluation date handling

### DIFF
--- a/core/migrations/0022_recruitmentemployee_evaluation_date.py
+++ b/core/migrations/0022_recruitmentemployee_evaluation_date.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0021_recruitmentemployee_report"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="recruitmentemployee",
+            name="evaluation_date",
+            field=models.DateField(
+                verbose_name="تاريخ آخر تقييم", null=True, blank=True
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -172,6 +172,9 @@ class RecruitmentEmployee(models.Model):
     final_score = models.DecimalField(
         "الدرجة النهائية", max_digits=5, decimal_places=2, null=True, blank=True
     )
+    evaluation_date = models.DateField(
+        "تاريخ آخر تقييم", null=True, blank=True
+    )
 
     class Meta:
         verbose_name = "موظف استقدام"
@@ -182,7 +185,9 @@ class RecruitmentEmployee(models.Model):
 
     @property
     def last_evaluation_date(self):
-        """Return date of the most recent evaluation if available."""
+        """Return stored evaluation date or date of the most recent evaluation."""
+        if self.evaluation_date:
+            return self.evaluation_date
         evaluation = self.evaluations.order_by("-evaluated_at").first()
         return evaluation.evaluated_at.date() if evaluation else None
 

--- a/core/views.py
+++ b/core/views.py
@@ -458,13 +458,13 @@ def input_evaluation_results(request):
             # التاريخ
             if raw_date:
                 try:
-                    emp.last_evaluation_date = datetime.date.fromisoformat(raw_date)
+                    emp.evaluation_date = datetime.date.fromisoformat(raw_date)
                     changed = True
                 except ValueError:
                     pass
-            elif emp.last_evaluation_date is None:
+            elif emp.evaluation_date is None:
                 # افتراضيًا اجعل التاريخ مطابقًا لتاريخ التقرير
-                emp.last_evaluation_date = emp.report.report_date
+                emp.evaluation_date = emp.report.report_date
                 changed = True
 
             if changed:


### PR DESCRIPTION
## Summary
- add `evaluation_date` field for recruitment employees
- compute `last_evaluation_date` from this field or evaluations
- adjust date saving logic in input_evaluation_results
- create migration for the new field

## Testing
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686287f73e5883329904494fb659732f