### PR TITLE
Fix evaluation form submission error

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -430,7 +430,7 @@ def input_evaluation_results(request):
 
         for emp in selected:
             raw_score  = request.POST.get(f"score_{emp.id}", "").strip()
-            raw_eval   = request.POST.get(f"evaluation_{emp.id}", "").strip()
+            raw_result = request.POST.get(f"result_{emp.id}", "").strip()
             raw_expect = request.POST.get(f"result_expectations_{emp.id}", "").strip()
             raw_date   = request.POST.get(f"date_{emp.id}", "").strip()
             changed = False
@@ -438,20 +438,20 @@ def input_evaluation_results(request):
             # Absent
             if raw_score.lower() == "absent":
                 emp.final_score = None
-                emp.evaluation = emp.result_expectations = "Absent"
+                emp.result = emp.result_expectations = "Absent"
                 changed = True
             elif raw_score:
                 try:
                     dec = Decimal(raw_score)
                     emp.final_score = dec
-                    emp.evaluation, emp.result_expectations = _grade_mapping(dec)
+                    emp.result, emp.result_expectations = _grade_mapping(dec)
                     changed = True
                 except Exception:
                     pass
 
             # يدوي
-            if raw_eval:
-                emp.evaluation = raw_eval; changed = True
+            if raw_result:
+                emp.result = raw_result; changed = True
             if raw_expect:
                 emp.result_expectations = raw_expect; changed = True
 

--- a/templates/core/input_results.html
+++ b/templates/core/input_results.html
@@ -122,8 +122,8 @@
           </td>
 
           <td class="px-2">
-            <input name="evaluation_{{ emp.id }}" id="eval-{{ emp.id }}"
-                   value="{{ emp.evaluation|default_if_none:'' }}"
+            <input name="result_{{ emp.id }}" id="res-{{ emp.id }}"
+                   value="{{ emp.result|default_if_none:'' }}"
                    class="border rounded px-2 py-1 w-full bg-gray-100 text-center" readonly />
           </td>
 
@@ -159,7 +159,7 @@
 <script>
 function calc(id){
   const score  = document.querySelector(`[name="score_${id}"]`).value.trim(),
-        evalEl = document.getElementById('eval-'+id),
+        evalEl = document.getElementById('res-'+id),
         expEl  = document.getElementById('exp-'+id);
 
   if(!score){ evalEl.value = expEl.value = ''; return; }


### PR DESCRIPTION
## Summary
- write letter grades to the `result` field instead of numeric `evaluation`
- update input names and JavaScript in the evaluation results page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68628c064ba483329fd9c9392dda8307