### PR TITLE
Add legacy recruitment record model

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -10,6 +10,7 @@ from .models import (
     RecruitmentEmployee,
     EmployeeEvaluation,
     RecruitmentReport,
+    LegacyRecruitmentRecord,
 )
 
 
@@ -65,4 +66,10 @@ class EmployeeEvaluationAdmin(admin.ModelAdmin):
 class RecruitmentReportAdmin(admin.ModelAdmin):
     list_display = ("filename", "report_date", "uploaded_at")
     search_fields = ("filename",)
+
+
+@admin.register(LegacyRecruitmentRecord)
+class LegacyRecruitmentRecordAdmin(admin.ModelAdmin):
+    list_display = ("emp_id", "name_ar", "year")
+    search_fields = ("emp_id", "name_ar", "name_en")
 

--- a/core/migrations/0023_legacyrecruitmentrecord.py
+++ b/core/migrations/0023_legacyrecruitmentrecord.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0022_recruitmentemployee_evaluation_date'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LegacyRecruitmentRecord',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('employees', models.CharField(max_length=100, verbose_name='Employees')),
+                ('emp_id', models.CharField(max_length=50, verbose_name='Emp. ID')),
+                ('evaluation', models.DecimalField(blank=True, decimal_places=2, max_digits=5, null=True, verbose_name='Evaliuation')),
+                ('result', models.CharField(blank=True, max_length=100, null=True, verbose_name='Result')),
+                ('result_expectations', models.CharField(blank=True, max_length=100, null=True, verbose_name='Result Expectations')),
+                ('name_ar', models.CharField(blank=True, max_length=100, null=True, verbose_name='Name (Arabic)')),
+                ('name_en', models.CharField(blank=True, max_length=100, null=True, verbose_name='Name (English)')),
+                ('passport_no', models.CharField(blank=True, max_length=100, null=True, verbose_name='Passport No.')),
+                ('nationality', models.CharField(blank=True, max_length=50, null=True, verbose_name='Nationality')),
+                ('profession', models.CharField(blank=True, max_length=100, null=True, verbose_name='Profession')),
+                ('profession_group', models.CharField(blank=True, max_length=100, null=True, verbose_name='Profession Group')),
+                ('sponsor', models.CharField(blank=True, max_length=100, null=True, verbose_name='Sponsor')),
+                ('date', models.DateField(blank=True, null=True, verbose_name='Date')),
+                ('month', models.CharField(blank=True, max_length=20, null=True, verbose_name='Month')),
+                ('month_number', models.PositiveSmallIntegerField(blank=True, null=True, verbose_name='Month Number')),
+                ('sector', models.CharField(blank=True, max_length=100, null=True, verbose_name='Sector')),
+                ('team_group', models.CharField(blank=True, max_length=100, null=True, verbose_name='Team Group')),
+                ('project', models.CharField(blank=True, max_length=100, null=True, verbose_name='Project')),
+                ('management', models.CharField(blank=True, max_length=100, null=True, verbose_name='Management')),
+                ('project_manager', models.CharField(blank=True, max_length=100, null=True, verbose_name='Project Manager')),
+                ('director_of_management', models.CharField(blank=True, max_length=100, null=True, verbose_name='Director of Management')),
+                ('year', models.PositiveIntegerField(blank=True, null=True, verbose_name='Year')),
+            ],
+            options={
+                'verbose_name': 'سجل استقدام قديم',
+                'verbose_name_plural': 'سجلات الاستقدام القديمة',
+            },
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -260,3 +260,49 @@ class RecruitmentReport(models.Model):
     def __str__(self) -> str:
         return f"{self.filename} - {self.report_date}"
 
+
+class LegacyRecruitmentRecord(models.Model):
+    """سجل قديم لبيانات الاستقدام."""
+
+    employees = models.CharField("Employees", max_length=100)
+    emp_id = models.CharField("Emp. ID", max_length=50)
+    evaluation = models.DecimalField(
+        "Evaliuation", max_digits=5, decimal_places=2, null=True, blank=True
+    )
+    result = models.CharField("Result", max_length=100, null=True, blank=True)
+    result_expectations = models.CharField(
+        "Result Expectations", max_length=100, null=True, blank=True
+    )
+    name_ar = models.CharField("Name (Arabic)", max_length=100, null=True, blank=True)
+    name_en = models.CharField("Name (English)", max_length=100, null=True, blank=True)
+    passport_no = models.CharField("Passport No.", max_length=100, null=True, blank=True)
+    nationality = models.CharField("Nationality", max_length=50, null=True, blank=True)
+    profession = models.CharField("Profession", max_length=100, null=True, blank=True)
+    profession_group = models.CharField(
+        "Profession Group", max_length=100, null=True, blank=True
+    )
+    sponsor = models.CharField("Sponsor", max_length=100, null=True, blank=True)
+    date = models.DateField("Date", null=True, blank=True)
+    month = models.CharField("Month", max_length=20, null=True, blank=True)
+    month_number = models.PositiveSmallIntegerField(
+        "Month Number", null=True, blank=True
+    )
+    sector = models.CharField("Sector", max_length=100, null=True, blank=True)
+    team_group = models.CharField("Team Group", max_length=100, null=True, blank=True)
+    project = models.CharField("Project", max_length=100, null=True, blank=True)
+    management = models.CharField("Management", max_length=100, null=True, blank=True)
+    project_manager = models.CharField(
+        "Project Manager", max_length=100, null=True, blank=True
+    )
+    director_of_management = models.CharField(
+        "Director of Management", max_length=100, null=True, blank=True
+    )
+    year = models.PositiveIntegerField("Year", null=True, blank=True)
+
+    class Meta:
+        verbose_name = "سجل استقدام قديم"
+        verbose_name_plural = "سجلات الاستقدام القديمة"
+
+    def __str__(self) -> str:
+        return f"{self.emp_id} - {self.name_ar or self.name_en}".strip()
+


### PR DESCRIPTION
## Summary
- introduce `LegacyRecruitmentRecord` for historical recruitment data
- register the new model with the admin
- add migration for the new database table

## Testing
- `python -m py_compile core/models.py core/admin.py core/migrations/0023_legacyrecruitmentrecord.py`
- ❌ `python manage.py makemigrations` *(failed: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e3b1cf96c83329583d3ebf3697171