### PR TITLE
Fix legacy import for textual results

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,6 @@ python manage.py import_legacy_excel path/to/legacy.xlsx
 
 Replace `path/to/legacy.xlsx` with the Excel file you wish to import. The
 command cleans the column names and bulk creates
-`LegacyRecruitmentRecord` entries.
+`LegacyRecruitmentRecord` entries. Numeric evaluation columns are converted
+using `pandas.to_numeric`, so invalid values become `NULL`, while textual
+results such as "The assessment cannot be conducted" are stored unchanged.

--- a/core/management/commands/import_legacy_excel.py
+++ b/core/management/commands/import_legacy_excel.py
@@ -54,6 +54,13 @@ class Command(BaseCommand):
         df.columns = [clean_name(c) for c in df.columns]
         df = df.rename(columns={k: v for k, v in COLUMN_FIELD_MAP.items() if k in df.columns})
 
+        # Clean textual result values and convert evaluation to numeric when possible
+        if 'result' in df.columns:
+            df['result'] = df['result'].fillna('').apply(clean_name)
+            df.loc[df['result'] == '', 'result'] = None
+        if 'evaluation' in df.columns:
+            df['evaluation'] = pd.to_numeric(df['evaluation'], errors='coerce')
+
         model_fields = {f.name for f in LegacyRecruitmentRecord._meta.get_fields()
                         if f.concrete and not f.auto_created}
 


### PR DESCRIPTION
## Summary
- sanitize legacy Excel results and evaluation values
- document evaluation conversion in README

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e53ce56c88332bb008769e0fe882c