### PR TITLE
Implement database update export

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
     path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),
     path("recruitment/<int:pk>/final-score/", views.set_final_score, name="set_final_score"),
+    path("recruitment/update-db/", views.update_database, name="update_database"),
 
     # فلترة شجرية تجريبية
     path("tree-filter/", views.tree_filter_page, name="tree_filter"),

--- a/core/views.py
+++ b/core/views.py
@@ -20,7 +20,7 @@ from django.template.defaultfilters import filesizeformat
 from django.urls import reverse
 from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_POST, require_http_methods
 
 from .forms import (
     EmployeeEvaluationForm,
@@ -585,3 +585,43 @@ def reports_json(request):
             "report_date": r.report_date.isoformat(),
         } for r in qs
     ], safe=False)
+
+
+@require_http_methods(["GET", "POST"])
+def update_database(request):
+    """Update employee results then return an Excel file."""
+    if request.method == "POST":
+        for emp in RecruitmentEmployee.objects.all():
+            if emp.final_score is None:
+                ev = emp.evaluations.order_by("-evaluated_at").first()
+                if ev:
+                    total = (
+                        Decimal(ev.appearance_score)
+                        + Decimal(ev.experience_score)
+                        + Decimal(ev.skills_score)
+                    ) / Decimal(3)
+                    emp.final_score = total.quantize(Decimal("0.01"))
+                    emp.evaluation_date = ev.evaluated_at.date()
+            if emp.final_score is not None:
+                emp.result, emp.result_expectations = _grade_mapping(emp.final_score)
+            emp.save()
+
+        data = RecruitmentEmployee.objects.values(
+            "serial",
+            "employee_number",
+            "name",
+            "final_score",
+            "result",
+            "result_expectations",
+            "evaluation_date",
+            "start_date",
+            "is_haramain",
+        )
+        df = pd.DataFrame(list(data))
+        resp = HttpResponse(content_type="application/vnd.ms-excel")
+        filename = f"recruitment_placeholder_{datetime.date.today():%Y%m%d}.xlsx"
+        resp["Content-Disposition"] = f'attachment; filename="{filename}"'
+        df.to_excel(resp, index=False)
+        return resp
+
+    return render(request, "core/update_db.html")

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -25,7 +25,7 @@
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-keyboard"></i></div></div>
       <div class="recruitment-name">إدخال نتائج التقييم</div>
     </a>
-    <a href="{% url 'core:recruitment_step' 'update_db' %}" class="recruitment-card" title="تحديث قاعدة البيانات">
+    <a href="{% url 'core:update_database' %}" class="recruitment-card" title="تحديث قاعدة البيانات">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-database"></i></div></div>
       <div class="recruitment-name">تحديث قاعدة البيانات</div>
     </a>

--- a/templates/core/update_db.html
+++ b/templates/core/update_db.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}تحديث قاعدة البيانات{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold text-center mb-6">تحديث قاعدة البيانات</h1>
+<form method="post" class="text-center">
+  {% csrf_token %}
+  <button type="submit" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+    <i class="fas fa-database"></i>
+    تحديث قاعدة البيانات
+  </button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated view to update recruitment database and export excel
- link the new view from dashboard
- route `recruitment/update-db/`
- provide simple page with a button to trigger the update

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e588dd3c0833281bd2a44fa45fd39