### PR TITLE
Add safety report import

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.db import IntegrityError
 from django.utils import timezone
+from django.urls import reverse
 import datetime
 
 from .models import (
@@ -10,6 +11,7 @@ from .models import (
     Department,
     Section,
 )
+from .models import LegacyRecruitmentRecord, RecruitmentReport
 
 
 class LearnerModelTest(TestCase):
@@ -126,4 +128,47 @@ class RecruitmentReportModelTest(TestCase):
             rows=[{"c": 1}],
         )
         self.assertEqual(str(rep), f"file.xlsx - {dt}")
+
+
+class ImportReportRecordsTest(TestCase):
+    """اختبار استيراد السجلات من الكشف المرفوع."""
+
+    def setUp(self):
+        from django.contrib.auth.models import User
+        self.user = User.objects.create_user(username="u", password="p")
+        self.report = RecruitmentReport.objects.create(
+            filename="safety.xlsx",
+            report_date=datetime.date(2024, 2, 1),
+            file_size=1,
+            is_haramain=False,
+            columns=[
+                "EMP NO",
+                "Name Arabic",
+                "Name English",
+                "Passport No",
+                "Nationality",
+                "Actual Profession",
+                "Sponsor Name",
+            ],
+            rows=[
+                {
+                    "EMP NO": "100",
+                    "Name Arabic": "أحمد",
+                    "Name English": "Ahmed",
+                    "Passport No": "P1",
+                    "Nationality": "SA",
+                    "Actual Profession": "Worker",
+                    "Sponsor Name": "ABC",
+                }
+            ],
+        )
+
+    def test_import_creates_record_once(self):
+        self.client.force_login(self.user)
+        url = reverse("core:import_report_records", args=[self.report.pk])
+        self.client.post(url)
+        self.assertEqual(LegacyRecruitmentRecord.objects.count(), 1)
+        # Second call should not duplicate
+        self.client.post(url)
+        self.assertEqual(LegacyRecruitmentRecord.objects.count(), 1)
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -65,6 +65,7 @@ urlpatterns = [
     path("recruitment/report/<int:pk>/delete/", views.delete_report, name="delete_report"),
     path("recruitment/report/<int:pk>/edit/", views.edit_report, name="edit_report"),
     path("recruitment/report/<int:pk>/export/", views.export_report_excel, name="export_report"),
+    path("recruitment/report/<int:pk>/import/", views.import_report_records, name="import_report_records"),
     path("recruitment/reports/json/", views.reports_json, name="reports_json"),
     path("recruitment/<int:pk>/evaluate/", views.evaluate_employee, name="evaluate_employee"),
     path("recruitment/input-results/", views.input_evaluation_results, name="input_evaluation_results"),

--- a/core/views.py
+++ b/core/views.py
@@ -33,6 +33,7 @@ from .models import (
     Nationality,
     RecruitmentEmployee,
     RecruitmentReport,
+    LegacyRecruitmentRecord,
     Sector,
     Section,
 )
@@ -56,6 +57,29 @@ EMPLOYEE_COLUMN_MAP: dict[str, list[str]] = {
     "result_expectations": ["result_expectations", "Result Expectations"],
     "start_date":          ["start_date", "تاريخ المباشرة"],
 }
+
+# ------------------------------------------------------------------------------
+# أعمدة كشف السلامة لاستيراد السجلات القديمة
+# ------------------------------------------------------------------------------
+LEGACY_COLUMN_MAP = {
+    "EMP NO": "emp_id",
+    "Emp. ID": "emp_id",
+    "Name Arabic": "name_ar",
+    "Name English": "name_en",
+    "Passport No": "passport_no",
+    "Nationality": "nationality",
+    "Actual Profession": "profession",
+    "Sponsor Name": "sponsor",
+}
+
+INVISIBLE_CHARS = {"\u200f", "\ufeff"}
+
+
+def _clean_header(name: str) -> str:
+    """Remove invisible characters and surrounding whitespace from a header."""
+    for ch in INVISIBLE_CHARS:
+        name = name.replace(ch, "")
+    return name.strip()
 
 # ------------------------------------------------------------------------------
 # صفحات عامة
@@ -359,6 +383,53 @@ def edit_report(request, pk):
         messages.success(request, "تم تحديث الكشف")
         return redirect("core:upload_employees")
     return render(request, "core/edit_report.html", {"form": form, "report": rep})
+
+
+@require_POST
+def import_report_records(request, pk):
+    """Import selected report rows into LegacyRecruitmentRecord."""
+    report = RecruitmentReport.objects.get(pk=pk)
+    required = {
+        "emp_id",
+        "name_ar",
+        "name_en",
+        "passport_no",
+        "nationality",
+        "profession",
+        "sponsor",
+    }
+
+    added = 0
+    skipped = 0
+    for raw in report.rows:
+        row = { _clean_header(k): v for k, v in raw.items() }
+        data = { field: row.get(col) for col, field in LEGACY_COLUMN_MAP.items() if col in row }
+        if not all(data.get(f) for f in required):
+            skipped += 1
+            logger.warning("Skipping row with missing data: %s", row)
+            continue
+        emp_id = str(data["emp_id"]).strip()
+        if LegacyRecruitmentRecord.objects.filter(emp_id=emp_id).exists():
+            skipped += 1
+            continue
+        LegacyRecruitmentRecord.objects.create(
+            emp_id=emp_id,
+            name_ar=str(data["name_ar"]).strip(),
+            name_en=str(data["name_en"]).strip(),
+            passport_no=str(data["passport_no"]).strip(),
+            nationality=str(data["nationality"]).strip(),
+            profession=str(data["profession"]).strip(),
+            sponsor=str(data["sponsor"]).strip(),
+        )
+        added += 1
+
+    if added:
+        messages.success(request, f"تم إضافة {added} سجل بنجاح")
+    else:
+        messages.info(request, "لا توجد سجلات جديدة لإضافتها")
+    if skipped:
+        messages.warning(request, f"تم تجاهل {skipped} سجل مكرر أو ناقص البيانات")
+    return redirect("core:upload_employees")
 
 # ------------------------------------------------------------------------------
 # تقييم فردي سريع

--- a/templates/core/upload_employees.html
+++ b/templates/core/upload_employees.html
@@ -128,6 +128,12 @@
                 <a href="{% url 'core:export_report' rep.id %}" class="action-btn tooltip text-green-600" data-tooltip="تحميل">
                   <i class="fa-solid fa-download"></i>
                 </a>
+                <form method="post" action="{% url 'core:import_report_records' rep.id %}" class="inline">
+                  {% csrf_token %}
+                  <button type="submit" class="action-btn tooltip text-purple-600" data-tooltip="إضافة إلى قاعدة البيانات">
+                    <i class="fa-solid fa-database"></i>
+                  </button>
+                </form>
                 <form method="post" action="{% url 'core:delete_report' rep.id %}" class="inline">
                   {% csrf_token %}
                   <button type="submit" class="action-btn tooltip text-red-600" data-tooltip="حذف">


### PR DESCRIPTION
## Summary
- allow importing uploaded safety reports to `LegacyRecruitmentRecord`
- add endpoint and button in the uploads table
- implement import logic with duplicate checking
- test importing a report

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686e5c5916e083328bffe5278d56a519