### PR TITLE
Add update-or-create import logic

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -2,7 +2,10 @@ from django.test import TestCase
 from django.db import IntegrityError
 from django.utils import timezone
 from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
 import datetime
+import io
+import pandas as pd
 
 from .models import (
     Learner,
@@ -11,7 +14,7 @@ from .models import (
     Department,
     Section,
 )
-from .models import LegacyRecruitmentRecord, RecruitmentReport
+from .models import LegacyRecruitmentRecord, RecruitmentReport, RecruitmentEmployee
 
 
 class LearnerModelTest(TestCase):
@@ -171,4 +174,39 @@ class ImportReportRecordsTest(TestCase):
         # Second call should not duplicate
         self.client.post(url)
         self.assertEqual(LegacyRecruitmentRecord.objects.count(), 1)
+
+
+class UploadEmployeesUpdateTest(TestCase):
+    """التأكد من تحديث السجلات الموجودة بدلاً من تكرارها."""
+
+    def _excel_file(self, rows):
+        buf = io.BytesIO()
+        pd.DataFrame(rows).to_excel(buf, index=False)
+        buf.seek(0)
+        return SimpleUploadedFile("rep.xlsx", buf.getvalue(), content_type="application/vnd.ms-excel")
+
+    def test_update_existing_employee(self):
+        url = reverse("core:upload_employees")
+
+        file1 = self._excel_file([
+            {"serial": 1, "employee_number": "10", "name": "Ali", "Evaluation": "The assessment cannot be conducted"},
+        ])
+        self.client.post(
+            url,
+            {"report_date": "2024-01-01", "is_haramain": "false", "file": file1},
+        )
+        self.assertEqual(RecruitmentEmployee.objects.count(), 1)
+        emp = RecruitmentEmployee.objects.get(employee_number="10")
+        self.assertEqual(emp.name, "Ali")
+
+        file2 = self._excel_file([
+            {"serial": 1, "employee_number": "10", "name": "Moh"},
+        ])
+        self.client.post(
+            url,
+            {"report_date": "2024-01-02", "is_haramain": "false", "file": file2},
+        )
+        self.assertEqual(RecruitmentEmployee.objects.count(), 1)
+        emp.refresh_from_db()
+        self.assertEqual(emp.name, "Moh")
 

--- a/core/views.py
+++ b/core/views.py
@@ -247,12 +247,19 @@ def _extract_employee_data(row: dict) -> dict:
                         val = pd.to_datetime(val).date()
                     except Exception:
                         val = None
+                elif field == "evaluation":
+                    try:
+                        val = Decimal(str(val))
+                    except Exception:
+                        val = None
                 data[field] = val
                 break
+
     serial = str(data.get("serial", "")).strip()
-    if not serial.isdigit():
-        return {}
-    data["serial"] = int(serial)
+    if serial.isdigit():
+        data["serial"] = int(serial)
+    else:
+        data.pop("serial", None)
     return data
 
 # ------------------------------------------------------------------------------
@@ -298,7 +305,15 @@ def upload_employees(request):
                 data = _extract_employee_data({k.strip(): v for k, v in r.items()})
                 if not data:
                     continue
-                RecruitmentEmployee.objects.create(report=report, is_haramain=is_haramain, **data)
+                emp_no = str(data.pop("employee_number", "")).strip()
+                if not emp_no:
+                    continue
+                defaults = {k: v for k, v in data.items() if v is not None}
+                defaults.update({"report": report, "is_haramain": is_haramain})
+                RecruitmentEmployee.objects.update_or_create(
+                    employee_number=emp_no,
+                    defaults=defaults,
+                )
                 added += 1
 
             saved += bool(added)


### PR DESCRIPTION
## Summary
- handle text values when parsing recruitment spreadsheets
- update existing `RecruitmentEmployee` rows based on employee number
- test that uploading a report updates an existing employee

## Testing
- `python manage.py test -v 0` *(fails: Couldn't import Django)*


------
https://chatgpt.com/codex/tasks/task_e_686e6636c81c8332ac2f210f5faa4918