### PR TITLE
Export all recruitment fields

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -138,6 +138,7 @@ class ImportReportRecordsTest(TestCase):
 
     def setUp(self):
         from django.contrib.auth.models import User
+
         self.user = User.objects.create_user(username="u", password="p")
         self.report = RecruitmentReport.objects.create(
             filename="safety.xlsx",
@@ -183,14 +184,23 @@ class UploadEmployeesUpdateTest(TestCase):
         buf = io.BytesIO()
         pd.DataFrame(rows).to_excel(buf, index=False)
         buf.seek(0)
-        return SimpleUploadedFile("rep.xlsx", buf.getvalue(), content_type="application/vnd.ms-excel")
+        return SimpleUploadedFile(
+            "rep.xlsx", buf.getvalue(), content_type="application/vnd.ms-excel"
+        )
 
     def test_update_existing_employee(self):
         url = reverse("core:upload_employees")
 
-        file1 = self._excel_file([
-            {"serial": 1, "employee_number": "10", "name": "Ali", "Evaluation": "The assessment cannot be conducted"},
-        ])
+        file1 = self._excel_file(
+            [
+                {
+                    "serial": 1,
+                    "employee_number": "10",
+                    "name": "Ali",
+                    "Evaluation": "The assessment cannot be conducted",
+                },
+            ]
+        )
         self.client.post(
             url,
             {"report_date": "2024-01-01", "is_haramain": "false", "file": file1},
@@ -199,9 +209,11 @@ class UploadEmployeesUpdateTest(TestCase):
         emp = RecruitmentEmployee.objects.get(employee_number="10")
         self.assertEqual(emp.name, "Ali")
 
-        file2 = self._excel_file([
-            {"serial": 1, "employee_number": "10", "name": "Moh"},
-        ])
+        file2 = self._excel_file(
+            [
+                {"serial": 1, "employee_number": "10", "name": "Moh"},
+            ]
+        )
         self.client.post(
             url,
             {"report_date": "2024-01-02", "is_haramain": "false", "file": file2},
@@ -210,3 +222,26 @@ class UploadEmployeesUpdateTest(TestCase):
         emp.refresh_from_db()
         self.assertEqual(emp.name, "Moh")
 
+
+class UpdateDatabaseExportTest(TestCase):
+    """Ensure exported placeholder includes all model fields."""
+
+    def test_export_all_columns(self):
+        emp = RecruitmentEmployee.objects.create(
+            serial=1,
+            employee_number="100",
+            name="Ali",
+        )
+
+        url = reverse("core:update_database")
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+
+        buf = io.BytesIO(resp.content)
+        df = pd.read_excel(buf)
+
+        fields = [f for f in RecruitmentEmployee._meta.fields if not f.auto_created]
+        expected = [getattr(f, "verbose_name", f.name) for f in fields]
+
+        self.assertEqual(list(df.columns), expected)
+        self.assertEqual(len(df), 1)

--- a/core/views.py
+++ b/core/views.py
@@ -677,18 +677,12 @@ def update_database(request):
                 emp.result, emp.result_expectations = _grade_mapping(emp.final_score)
             emp.save()
 
-        data = RecruitmentEmployee.objects.values(
-            "serial",
-            "employee_number",
-            "name",
-            "final_score",
-            "result",
-            "result_expectations",
-            "evaluation_date",
-            "start_date",
-            "is_haramain",
-        )
-        df = pd.DataFrame(list(data))
+        fields = [f for f in RecruitmentEmployee._meta.fields if not f.auto_created]
+        field_names = [f.name for f in fields]
+        headers = [getattr(f, "verbose_name", f.name) for f in fields]
+
+        data = RecruitmentEmployee.objects.values_list(*field_names)
+        df = pd.DataFrame(list(data), columns=headers)
         resp = HttpResponse(content_type="application/vnd.ms-excel")
         filename = f"recruitment_placeholder_{datetime.date.today():%Y%m%d}.xlsx"
         resp["Content-Disposition"] = f'attachment; filename="{filename}"'


### PR DESCRIPTION
## Summary
- export all `RecruitmentEmployee` columns with model order and names
- test placeholder export contains every column

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f5a992f3c8332b832e23800a42594