### PR TITLE
Handle timezone-aware datetimes in Excel export

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -683,6 +683,12 @@ def update_database(request):
 
         data = RecruitmentEmployee.objects.values_list(*field_names)
         df = pd.DataFrame(list(data), columns=headers)
+
+        # Excel cannot handle timezone-aware datetimes. Convert any timezone-
+        # aware values to naive datetimes before exporting.
+        df = df.applymap(
+            lambda v: v.replace(tzinfo=None) if isinstance(v, datetime.datetime) and v.tzinfo else v
+        )
         resp = HttpResponse(content_type="application/vnd.ms-excel")
         filename = f"recruitment_placeholder_{datetime.date.today():%Y%m%d}.xlsx"
         resp["Content-Disposition"] = f'attachment; filename="{filename}"'

--- a/test_update_database.py
+++ b/test_update_database.py
@@ -1,0 +1,24 @@
+import io
+import pandas as pd
+import datetime
+from django.urls import reverse
+from django.test import TestCase
+from django.utils import timezone
+from core.models import RecruitmentEmployee
+
+class UpdateDatabaseTimezoneTest(TestCase):
+    def test_export_removes_timezone(self):
+        RecruitmentEmployee.objects.create(
+            serial=1, employee_number="10", name="Ali"
+        )
+
+        url = reverse("core:update_database")
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+
+        buf = io.BytesIO(resp.content)
+        df = pd.read_excel(buf)
+
+        self.assertIn("created at", df.columns)
+        value = df.loc[0, "created at"]
+        self.assertFalse(hasattr(value, 'tzinfo') and value.tzinfo)


### PR DESCRIPTION
## Summary
- strip timezone info from datetimes before exporting recruitment data
- add regression test for timezone stripping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f5d37d13483328936d5146d793b6d