### PR TITLE
Fix recruitment export columns

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -245,3 +245,21 @@ class UpdateDatabaseExportTest(TestCase):
 
         self.assertEqual(list(df.columns), expected)
         self.assertEqual(len(df), 1)
+
+
+class UpdateDatabaseEmptyExportTest(TestCase):
+    """Export should include columns even when no records exist."""
+
+    def test_export_no_records(self):
+        url = reverse("core:update_database")
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+
+        buf = io.BytesIO(resp.content)
+        df = pd.read_excel(buf)
+
+        fields = [f for f in RecruitmentEmployee._meta.fields if not f.auto_created]
+        expected = [getattr(f, "verbose_name", f.name) for f in fields]
+
+        self.assertEqual(list(df.columns), expected)
+        self.assertEqual(len(df), 0)

--- a/core/views.py
+++ b/core/views.py
@@ -681,8 +681,19 @@ def update_database(request):
         field_names = [f.name for f in fields]
         headers = [getattr(f, "verbose_name", f.name) for f in fields]
 
-        data = RecruitmentEmployee.objects.values_list(*field_names)
-        df = pd.DataFrame(list(data), columns=headers)
+        # Build dataframe from explicit list of field names to ensure all
+        # columns are present even if no value exists yet. The order matches the
+        # model definition so it is consistent with the master schema.
+        data = RecruitmentEmployee.objects.all().values(*field_names)
+        df = pd.DataFrame(list(data))
+
+        # Add any missing columns (shouldn't normally occur) and reindex to the
+        # expected order before assigning verbose headers.
+        for col in field_names:
+            if col not in df:
+                df[col] = ""
+        df = df.reindex(columns=field_names)
+        df.columns = headers
 
         # Excel cannot handle timezone-aware datetimes. Convert any timezone-
         # aware values to naive datetimes before exporting.


### PR DESCRIPTION
## Summary
- ensure update database export always includes all columns in model order
- test export when no records exist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f5f32752c8332a591b53482e84324