### PR TITLE
Fix blank rows in export

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ command cleans the column names and bulk creates
 `LegacyRecruitmentRecord` entries. Numeric evaluation columns are converted
 using `pandas.to_numeric`, so invalid values become `NULL`, while textual
 results such as "The assessment cannot be conducted" are stored unchanged.
+
+## Cleaning Legacy Records
+
+Two maintenance commands are available to tidy the legacy data:
+
+```bash
+python manage.py cleanup_legacy_records
+python manage.py clear_sponsor_column
+```
+
+The first command removes entries that contain no real values. The second command clears the `sponsor` field for the first 33,822 records, which fixes earlier imports where that column contained incorrect information.

--- a/core/management/commands/cleanup_legacy_records.py
+++ b/core/management/commands/cleanup_legacy_records.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from core.models import LegacyRecruitmentRecord
+
+
+class Command(BaseCommand):
+    help = "Delete empty LegacyRecruitmentRecord entries"
+
+    def handle(self, *args, **options):
+        fields = [
+            f.name
+            for f in LegacyRecruitmentRecord._meta.get_fields()
+            if f.concrete and not f.auto_created and f.name != "id"
+        ]
+
+        ids = []
+        for rec in LegacyRecruitmentRecord.objects.all().iterator():
+            values = [getattr(rec, f) for f in fields]
+            if all(v in (None, "") for v in values):
+                ids.append(rec.id)
+
+        if ids:
+            LegacyRecruitmentRecord.objects.filter(id__in=ids).delete()
+            self.stdout.write(
+                self.style.SUCCESS(f"Deleted {len(ids)} empty records")
+            )
+        else:
+            self.stdout.write("No empty records found")
+

--- a/core/management/commands/clear_sponsor_column.py
+++ b/core/management/commands/clear_sponsor_column.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+from core.models import LegacyRecruitmentRecord
+
+
+class Command(BaseCommand):
+    help = "Clear sponsor values for the first 33822 legacy records"
+
+    def handle(self, *args, **options):
+        ids = list(
+            LegacyRecruitmentRecord.objects.order_by("id")
+            .values_list("id", flat=True)[:33822]
+        )
+        if not ids:
+            self.stdout.write("No records found")
+            return
+
+        updated = LegacyRecruitmentRecord.objects.filter(id__in=ids).update(sponsor=None)
+        self.stdout.write(self.style.SUCCESS(f"Cleared sponsor for {updated} records"))
+

--- a/core/views.py
+++ b/core/views.py
@@ -691,6 +691,10 @@ def update_database(request):
         qs = LegacyRecruitmentRecord.objects.all()
         df = pd.DataFrame(list(qs.values(*field_map.keys())))
 
+        # Remove completely empty rows before exporting
+        df = df.dropna(how="all")
+        df = df[~(df == "").all(axis=1)]
+
         # 2) Rename columns to match the expected export headers
         df.rename(columns=field_map, inplace=True)
 


### PR DESCRIPTION
## Summary
- drop empty rows before exporting legacy recruitment records
- add `cleanup_legacy_records` management command to remove empty DB entries
- add command to clear bad sponsor data

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f6c6e3b30833292b0798464e3a4d6