### PR TITLE
Add debug print in update_database view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -695,6 +695,7 @@ def update_database(request):
         qs = LegacyRecruitmentRecord.objects.all()
         data = list(qs.values(*field_map.keys()))
         df = pd.DataFrame.from_records(data, columns=field_map.keys())
+        print(df[["emp_id", "sponsor"]].head(20))
 
         # Remove completely empty rows before exporting
         df = df.dropna(how="all")


### PR DESCRIPTION
## Summary
- emit top 20 `emp_id`/`sponsor` rows when exporting recruitment records

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f79b31dec8332bcd046b39ad58cc3