### PR TITLE
Handle Arabic headers when importing Excel files

### DIFF
--- a/core/management/commands/import_legacy_excel.py
+++ b/core/management/commands/import_legacy_excel.py
@@ -4,29 +4,43 @@ import pandas as pd
 
 # Mapping from cleaned Excel columns to model field names
 COLUMN_FIELD_MAP = {
-    'Employees': 'employees',
-    'Emp. ID': 'emp_id',
-    'Evaliuation': 'evaluation',
-    'Result': 'result',
-    'Result Expectations': 'result_expectations',
-    'Name (Arabic)': 'name_ar',
-    'Name (English)': 'name_en',
-    'Passport No.': 'passport_no',
-    'Nationality': 'nationality',
-    'Profession': 'profession',
-    'Profession Group': 'profession_group',
-    'Sponsor': 'sponsor',
-    'Date': 'date',
-    'Month': 'month',
-    'Month Number': 'month_number',
-    'Sector': 'sector',
-    'Team Group': 'team_group',
-    'Project': 'project',
-    'Management': 'management',
-    'Project Manager': 'project_manager',
-    'Director of Management': 'director_of_management',
-    'Year': 'year',
+    "Employees": "employees",
+    "Emp. ID": "emp_id",
+    "Evaliuation": "evaluation",
+    "Result": "result",
+    "Result Expectations": "result_expectations",
+    "Name (Arabic)": "name_ar",
+    "Name (English)": "name_en",
+    "Passport No.": "passport_no",
+    "Nationality": "nationality",
+    "Profession": "profession",
+    "Profession Group": "profession_group",
+    "Sponsor": "sponsor",
+    "Date": "date",
+    "Month": "month",
+    "Month Number": "month_number",
+    "Sector": "sector",
+    "Team Group": "team_group",
+    "Project": "project",
+    "Management": "management",
+    "Project Manager": "project_manager",
+    "Director of Management": "director_of_management",
+    "Year": "year",
 }
+
+# Additional mappings for Arabic column headers
+ARABIC_COLUMN_MAP = {
+    "الرقم الوظيفي": "emp_id",
+    "الاسم عربي": "name_ar",
+    "الاسم انجليزي": "name_en",
+    "رقم الجواز": "passport_no",
+    "الجنسية": "nationality",
+    "المهنة": "profession",
+    "اسم الكفيل": "sponsor",
+}
+
+# Combine both maps for renaming
+COLUMN_MAP = {**COLUMN_FIELD_MAP, **ARABIC_COLUMN_MAP}
 
 INVISIBLE_CHARS = {
     '\u200f',  # RTL mark
@@ -52,7 +66,7 @@ class Command(BaseCommand):
 
         df = pd.read_excel(path)
         df.columns = [clean_name(c) for c in df.columns]
-        df = df.rename(columns={k: v for k, v in COLUMN_FIELD_MAP.items() if k in df.columns})
+        df.rename(columns=COLUMN_MAP, inplace=True)
 
         # Clean textual result values and convert evaluation to numeric when possible
         if 'result' in df.columns:

--- a/core/tests.py
+++ b/core/tests.py
@@ -176,6 +176,47 @@ class ImportReportRecordsTest(TestCase):
         self.client.post(url)
         self.assertEqual(LegacyRecruitmentRecord.objects.count(), 2)
 
+    def test_import_arabic_headers(self):
+        """Ensure Arabic column names are mapped correctly."""
+        report = RecruitmentReport.objects.create(
+            filename="arabic.xlsx",
+            report_date=datetime.date(2024, 3, 1),
+            file_size=1,
+            is_haramain=False,
+            columns=[
+                "الرقم الوظيفي",
+                "الاسم عربي",
+                "الاسم انجليزي",
+                "رقم الجواز",
+                "الجنسية",
+                "المهنة",
+                "اسم الكفيل",
+            ],
+            rows=[
+                {
+                    "الرقم الوظيفي": "200",
+                    "الاسم عربي": "سامي",
+                    "الاسم انجليزي": "Sami",
+                    "رقم الجواز": "P2",
+                    "الجنسية": "EG",
+                    "المهنة": "Engineer",
+                    "اسم الكفيل": "XYZ",
+                }
+            ],
+        )
+
+        self.client.force_login(self.user)
+        url = reverse("core:import_report_records", args=[report.pk])
+        self.client.post(url)
+
+        rec = LegacyRecruitmentRecord.objects.get(emp_id="200")
+        self.assertEqual(rec.name_ar, "سامي")
+        self.assertEqual(rec.name_en, "Sami")
+        self.assertEqual(rec.passport_no, "P2")
+        self.assertEqual(rec.nationality, "EG")
+        self.assertEqual(rec.profession, "Engineer")
+        self.assertEqual(rec.sponsor, "XYZ")
+
 
 class UploadEmployeesUpdateTest(TestCase):
     """التأكد من تحديث السجلات الموجودة بدلاً من تكرارها."""

--- a/core/views.py
+++ b/core/views.py
@@ -70,6 +70,14 @@ LEGACY_COLUMN_MAP = {
     "Nationality": "nationality",
     "Actual Profession": "profession",
     "Sponsor Name": "sponsor",
+    # Arabic headers
+    "الرقم الوظيفي": "emp_id",
+    "الاسم عربي": "name_ar",
+    "الاسم انجليزي": "name_en",
+    "رقم الجواز": "passport_no",
+    "الجنسية": "nationality",
+    "المهنة": "profession",
+    "اسم الكفيل": "sponsor",
 }
 
 INVISIBLE_CHARS = {"\u200f", "\ufeff"}
@@ -408,24 +416,23 @@ def edit_report(request, pk):
 def import_report_records(request, pk):
     """Import selected report rows into LegacyRecruitmentRecord."""
     report = RecruitmentReport.objects.get(pk=pk)
+
+    df = pd.DataFrame(report.rows)
+    df.columns = [_clean_header(c) for c in df.columns]
+    df.rename(columns=LEGACY_COLUMN_MAP, inplace=True)
+
     added = 0
-    for raw in report.rows:
-        row = {_clean_header(k): v for k, v in raw.items()}
-        data = {
-            field: row.get(col)
-            for col, field in LEGACY_COLUMN_MAP.items()
-            if col in row
-        }
-        emp_id = str(data.get("emp_id", "")).strip()
+    for _, row in df.iterrows():
+        emp_id = str(row.get("emp_id", "")).strip()
         LegacyRecruitmentRecord.objects.create(
             employees=emp_id,
             emp_id=emp_id,
-            name_ar=(str(data.get("name_ar", "")).strip() or None),
-            name_en=(str(data.get("name_en", "")).strip() or None),
-            passport_no=(str(data.get("passport_no", "")).strip() or None),
-            nationality=(str(data.get("nationality", "")).strip() or None),
-            profession=(str(data.get("profession", "")).strip() or None),
-            sponsor=(str(data.get("sponsor", "")).strip() or None),
+            name_ar=(str(row.get("name_ar", "")).strip() or None),
+            name_en=(str(row.get("name_en", "")).strip() or None),
+            passport_no=(str(row.get("passport_no", "")).strip() or None),
+            nationality=(str(row.get("nationality", "")).strip() or None),
+            profession=(str(row.get("profession", "")).strip() or None),
+            sponsor=(str(row.get("sponsor", "")).strip() or None),
         )
         added += 1
 

--- a/import_legacy.py
+++ b/import_legacy.py
@@ -6,29 +6,43 @@ EXCEL_FILE = 'legacy.xlsx'
 
 # Mapping from Excel columns to LegacyRecruitmentRecord fields after cleaning
 COLUMN_FIELD_MAP = {
-    'Employees': 'employees',
-    'Emp. ID': 'emp_id',
-    'Evaliuation': 'evaluation',
-    'Result': 'result',
-    'Result Expectations': 'result_expectations',
-    'Name (Arabic)': 'name_ar',
-    'Name (English)': 'name_en',
-    'Passport No.': 'passport_no',
-    'Nationality': 'nationality',
-    'Profession': 'profession',
-    'Profession Group': 'profession_group',
-    'Sponsor': 'sponsor',
-    'Date': 'date',
-    'Month': 'month',
-    'Month Number': 'month_number',
-    'Sector': 'sector',
-    'Team Group': 'team_group',
-    'Project': 'project',
-    'Management': 'management',
-    'Project Manager': 'project_manager',
-    'Director of Management': 'director_of_management',
-    'Year': 'year',
+    "Employees": "employees",
+    "Emp. ID": "emp_id",
+    "Evaliuation": "evaluation",
+    "Result": "result",
+    "Result Expectations": "result_expectations",
+    "Name (Arabic)": "name_ar",
+    "Name (English)": "name_en",
+    "Passport No.": "passport_no",
+    "Nationality": "nationality",
+    "Profession": "profession",
+    "Profession Group": "profession_group",
+    "Sponsor": "sponsor",
+    "Date": "date",
+    "Month": "month",
+    "Month Number": "month_number",
+    "Sector": "sector",
+    "Team Group": "team_group",
+    "Project": "project",
+    "Management": "management",
+    "Project Manager": "project_manager",
+    "Director of Management": "director_of_management",
+    "Year": "year",
 }
+
+# Additional mappings for Arabic headers
+ARABIC_COLUMN_MAP = {
+    "الرقم الوظيفي": "emp_id",
+    "الاسم عربي": "name_ar",
+    "الاسم انجليزي": "name_en",
+    "رقم الجواز": "passport_no",
+    "الجنسية": "nationality",
+    "المهنة": "profession",
+    "اسم الكفيل": "sponsor",
+}
+
+# Unified map used for renaming
+COLUMN_MAP = {**COLUMN_FIELD_MAP, **ARABIC_COLUMN_MAP}
 
 # Characters sometimes hidden in Excel headers
 INVISIBLE_CHARS = {'\u200f', '\ufeff'}
@@ -49,7 +63,7 @@ def main():
     df.columns = [clean_name(c) for c in df.columns]
 
     # Rename columns to match model field names
-    df = df.rename(columns={k: v for k, v in COLUMN_FIELD_MAP.items() if k in df.columns})
+    df.rename(columns=COLUMN_MAP, inplace=True)
 
     # Clean textual result values but keep all rows
     if 'result' in df.columns:


### PR DESCRIPTION
## Summary
- extend `import_legacy_excel` command to recognise Arabic columns
- support Arabic headers in the standalone `import_legacy.py`
- map Arabic column names in views when importing archived reports
- test importing reports with Arabic column headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686f893f35e88332b10d805867047768