### PR TITLE
Improve employee import script

### DIFF
--- a/import_employees.py
+++ b/import_employees.py
@@ -6,26 +6,44 @@ from pathlib import Path
 
 import pandas as pd
 
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 # Adjust these constants before running
 EXCEL_FILE = 'data.xlsx'
 DEFAULT_DATE = date(2025, 7, 10)
 DEFAULT_SECTOR = 'حرمين'  # or 'غير حرمين'
 
-# Map Excel headers to RecruitmentEmployee model fields
+# Map original Excel headers to our internal names
 COLUMN_MAP = {
-    'الرقم الوظيفي': 'employee_number',
+    'الرقم الوظيفي': 'emp_id',
+    'الاسم عربي': 'name_ar',
+    'الاسم انجليزي': 'name_en',
+    'المهنة': 'profession',
+    'رقم الجواز': 'passport_no',
+    'الجنسية': 'nationality',
+    'اسم الكفيل': 'sponsor',
     'Evaluation': 'evaluation',
     'Result': 'result',
     'Result Expectations': 'result_expectations',
-    'الاسم عربي': 'name',
-    'الاسم انجليزي': 'name_en',
-    'رقم الجواز': 'passport_number',
-    'الجنسية': 'nationality',
-    'المهنة': 'official_job',
-    'اسم الكفيل': 'sponsor_name',
-    'التاريخ': 'start_date',
+    'التاريخ': 'date',
     'القطاع': 'sector',
     'السنة': 'year',
+}
+
+# Mapping from internal names to `RecruitmentEmployee` model fields
+FIELD_MAP = {
+    'emp_id': 'employee_number',
+    'name_ar': 'name',
+    'name_en': 'name_en',
+    'profession': 'official_job',
+    'passport_no': 'passport_number',
+    'nationality': 'nationality',
+    'sponsor': 'sponsor_name',
+    'evaluation': 'evaluation',
+    'result': 'result',
+    'result_expectations': 'result_expectations',
+    'date': 'start_date',
 }
 
 # Django setup
@@ -46,52 +64,69 @@ def clean_header(name: str) -> str:
 def read_excel(path: str) -> pd.DataFrame:
     df = pd.read_excel(path)
     df.columns = [clean_header(c) for c in df.columns]
-    # Drop the serial column entirely if present
-    for col in ['المسلسل', 'serial']:
-        if col in df.columns:
+    # Remove unwanted columns such as the serial number
+    for col in list(df.columns):
+        if clean_header(col) in ('المسلسل', 'serial'):
             df.drop(columns=[col], inplace=True)
-    # Rename to match model fields
+    # Rename to our internal names
     df.rename(columns=COLUMN_MAP, inplace=True)
+
+    unknown = [c for c in df.columns if c not in COLUMN_MAP.values()]
+    if unknown:
+        print(f"تحذير: سيتم تجاهل الأعمدة غير المعروفة: {', '.join(unknown)}")
+        df.drop(columns=unknown, inplace=True)
+
+    # Keep only columns that have a mapping
+    df = df[[c for c in df.columns if c in COLUMN_MAP.values()]]
     return df
 
 
 def fill_missing_columns(df: pd.DataFrame) -> pd.DataFrame:
-    if 'start_date' not in df:
-        df['start_date'] = DEFAULT_DATE
+    if 'date' not in df:
+        df['date'] = DEFAULT_DATE
     else:
-        df['start_date'] = pd.to_datetime(df['start_date'], errors='coerce').fillna(DEFAULT_DATE).dt.date
+        df['date'] = (
+            pd.to_datetime(df['date'], errors='coerce')
+            .fillna(DEFAULT_DATE)
+            .dt.date
+        )
 
     if 'sector' not in df:
         df['sector'] = DEFAULT_SECTOR
     if 'year' not in df:
-        df['year'] = pd.to_datetime(df['start_date']).dt.year
+        df['year'] = pd.to_datetime(df['date']).dt.year
 
     df['is_haramain'] = df['sector'].astype(str).str.strip() == 'حرمين'
     return df
 
 
 def import_rows(df: pd.DataFrame) -> int:
-    model_fields = {
-        f.name for f in RecruitmentEmployee._meta.get_fields()
-        if f.concrete and not f.auto_created
-    }
-    records = []
-    for row in df.to_dict(orient='records'):
-        data = {k: row.get(k) for k in model_fields if k in row}
-        # Convert decimals
+    count = 0
+    for idx, row in df.iterrows():
+        data = {}
+        for col, model_field in FIELD_MAP.items():
+            if col in row:
+                data[model_field] = row[col]
+
+        # handle decimal conversion
         if data.get('evaluation') not in (None, ''):
             try:
                 data['evaluation'] = Decimal(str(data['evaluation']))
             except Exception:
-                data['evaluation'] = None
+                print(f"خطأ في الصف {idx + 1}: قيمة evaluation غير صالحة")
+                continue
+
+        data['is_haramain'] = str(row.get('sector', '')).strip() == 'حرمين'
+
         if data.get('start_date') == '':
             data['start_date'] = None
-        if not any(value not in (None, '') for value in data.values()):
-            continue
-        records.append(RecruitmentEmployee(**data))
-    if records:
-        RecruitmentEmployee.objects.bulk_create(records)
-    return len(records)
+
+        try:
+            RecruitmentEmployee.objects.create(**data)
+            count += 1
+        except Exception as e:
+            print(f"خطأ في الصف {idx + 1}: {e}")
+    return count
 
 
 def main():
@@ -103,7 +138,7 @@ def main():
     df = fill_missing_columns(df)
 
     count = import_rows(df)
-    print(f"Imported {count} employees")
+    print(f"تمت إضافة {count} سجلًا")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- extend import_employees.py
  - map Excel headers to field names, drop unknown columns
  - fill missing date, sector and year values
  - create each employee individually and report errors
  - print how many rows were imported

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fa6936bbc83328fe9f684b699fe2b