### PR TITLE
Fix sponsor import from Excel

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -348,3 +348,31 @@ class UpdateDatabaseEmptyExportTest(TestCase):
 
         self.assertEqual(list(df.columns), expected)
         self.assertEqual(len(df), 0)
+
+
+class UploadEmployeesHeaderCleaningTest(TestCase):
+    """Ensure hidden characters in headers don't prevent data import."""
+
+    def _excel_file(self, rows):
+        buf = io.BytesIO()
+        pd.DataFrame(rows).to_excel(buf, index=False)
+        buf.seek(0)
+        return SimpleUploadedFile(
+            "rep.xlsx", buf.getvalue(), content_type="application/vnd.ms-excel"
+        )
+
+    def test_import_sponsor_with_invisible_header(self):
+        url = reverse("core:upload_employees")
+
+        hidden_header = "\u200fاسم الكفيل"
+        file = self._excel_file(
+            [{"employee_number": "1", "name": "Ali", hidden_header: "Kafil"}]
+        )
+
+        self.client.post(
+            url,
+            {"report_date": "2024-01-01", "is_haramain": "false", "file": file},
+        )
+
+        emp = RecruitmentEmployee.objects.get(employee_number="1")
+        self.assertEqual(emp.sponsor_name, "Kafil")

--- a/core/views.py
+++ b/core/views.py
@@ -245,11 +245,13 @@ def other_services(request):
 # ------------------------------------------------------------------------------
 
 def _extract_employee_data(row: dict) -> dict:
+    """Return cleaned values from a raw Excel row."""
+    cleaned = {_clean_header(k): v for k, v in row.items()}
     data: dict[str, object] = {}
     for field, aliases in EMPLOYEE_COLUMN_MAP.items():
         for a in aliases:
-            if a in row and row[a] not in ("", None):
-                val = row[a]
+            if a in cleaned and cleaned[a] not in ("", None):
+                val = cleaned[a]
                 if field == "start_date":
                     try:
                         val = pd.to_datetime(val).date()


### PR DESCRIPTION
## Summary
- clean column headers when extracting employee data
- test sponsor extraction when Excel header has hidden characters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fa914426c8332884b75bfdff1a33f