### PR TITLE
Fix sponsor import from Excel

### DIFF
--- a/core/management/commands/import_legacy_excel.py
+++ b/core/management/commands/import_legacy_excel.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.models import LegacyRecruitmentRecord
 import pandas as pd
+import re
 
 # Mapping from cleaned Excel columns to model field names
 COLUMN_FIELD_MAP = {
@@ -49,10 +50,13 @@ INVISIBLE_CHARS = {
 
 
 def clean_name(name: str) -> str:
-    """Remove invisible characters and strip whitespace."""
+    """Normalize Excel column headers by stripping extras."""
+    name = str(name)
     for ch in INVISIBLE_CHARS:
         name = name.replace(ch, '')
-    return name.strip()
+    name = name.strip()
+    name = re.sub(r'[:\u0589\u061b]+$', '', name).strip()
+    return name
 
 
 class Command(BaseCommand):

--- a/core/tests.py
+++ b/core/tests.py
@@ -348,3 +348,47 @@ class UpdateDatabaseEmptyExportTest(TestCase):
 
         self.assertEqual(list(df.columns), expected)
         self.assertEqual(len(df), 0)
+
+
+class UploadEmployeesHeaderCleaningTest(TestCase):
+    """Ensure hidden characters in headers don't prevent data import."""
+
+    def _excel_file(self, rows):
+        buf = io.BytesIO()
+        pd.DataFrame(rows).to_excel(buf, index=False)
+        buf.seek(0)
+        return SimpleUploadedFile(
+            "rep.xlsx", buf.getvalue(), content_type="application/vnd.ms-excel"
+        )
+
+    def test_import_sponsor_with_invisible_header(self):
+        url = reverse("core:upload_employees")
+
+        hidden_header = "\u200fاسم الكفيل"
+        file = self._excel_file(
+            [{"employee_number": "1", "name": "Ali", hidden_header: "Kafil"}]
+        )
+
+        self.client.post(
+            url,
+            {"report_date": "2024-01-01", "is_haramain": "false", "file": file},
+        )
+
+        emp = RecruitmentEmployee.objects.get(employee_number="1")
+        self.assertEqual(emp.sponsor_name, "Kafil")
+
+    def test_import_sponsor_with_colon_header(self):
+        url = reverse("core:upload_employees")
+
+        header_with_colon = "اسم الكفيل:"
+        file = self._excel_file(
+            [{"employee_number": "2", "name": "Omar", header_with_colon: "SponX"}]
+        )
+
+        self.client.post(
+            url,
+            {"report_date": "2024-01-01", "is_haramain": "false", "file": file},
+        )
+
+        emp = RecruitmentEmployee.objects.get(employee_number="2")
+        self.assertEqual(emp.sponsor_name, "SponX")

--- a/core/views.py
+++ b/core/views.py
@@ -84,10 +84,13 @@ INVISIBLE_CHARS = {"\u200f", "\ufeff"}
 
 
 def _clean_header(name: str) -> str:
-    """Remove invisible characters and surrounding whitespace from a header."""
+    """Normalize Excel column headers by stripping extras."""
+    name = str(name)
     for ch in INVISIBLE_CHARS:
         name = name.replace(ch, "")
-    return name.strip()
+    name = name.strip()
+    name = re.sub(r"[:\u0589\u061b]+$", "", name).strip()
+    return name
 
 # ------------------------------------------------------------------------------
 # صفحات عامة
@@ -245,11 +248,13 @@ def other_services(request):
 # ------------------------------------------------------------------------------
 
 def _extract_employee_data(row: dict) -> dict:
+    """Return cleaned values from a raw Excel row."""
+    cleaned = {_clean_header(k): v for k, v in row.items()}
     data: dict[str, object] = {}
     for field, aliases in EMPLOYEE_COLUMN_MAP.items():
         for a in aliases:
-            if a in row and row[a] not in ("", None):
-                val = row[a]
+            if a in cleaned and cleaned[a] not in ("", None):
+                val = cleaned[a]
                 if field == "start_date":
                     try:
                         val = pd.to_datetime(val).date()

--- a/import_employees.py
+++ b/import_employees.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from pathlib import Path
 
 import pandas as pd
+import re
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -55,10 +56,13 @@ from core.models import RecruitmentEmployee
 # --------------------------------------------------------------------------------------
 
 def clean_header(name: str) -> str:
-    """Strip whitespace and remove hidden characters from column headers."""
+    """Strip whitespace, punctuation, and hidden characters from headers."""
+    name = str(name)
     for ch in ('\u200f', '\ufeff'):
         name = name.replace(ch, '')
-    return str(name).strip()
+    name = name.strip()
+    name = re.sub(r'[:\u0589\u061b]+$', '', name).strip()
+    return name
 
 
 def read_excel(path: str) -> pd.DataFrame:

--- a/import_legacy.py
+++ b/import_legacy.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import re
 from core.models import LegacyRecruitmentRecord
 
 # Path to the Excel file to import. Adjust this before running.
@@ -49,10 +50,13 @@ INVISIBLE_CHARS = {'\u200f', '\ufeff'}
 
 
 def clean_name(name: str) -> str:
-    """Strip whitespace and remove invisible characters."""
+    """Strip whitespace, punctuation, and invisible characters."""
+    name = str(name)
     for ch in INVISIBLE_CHARS:
         name = name.replace(ch, '')
-    return name.strip()
+    name = name.strip()
+    name = re.sub(r'[:\u0589\u061b]+$', '', name).strip()
+    return name
 
 
 def main():


### PR DESCRIPTION
## Summary
- clean more column header characters when extracting employee data
- update import scripts to normalize header text
- test sponsor extraction when Excel header ends with a colon

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fa914426c8332884b75bfdff1a33f