### PR TITLE
Fix sponsor name mapping for Excel import

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -423,3 +423,19 @@ class UploadEmployeesHeaderCleaningTest(TestCase):
 
         emp = RecruitmentEmployee.objects.get(employee_number="4")
         self.assertEqual(emp.sponsor_name, "NewKafil")
+
+    def test_import_sponsor_with_duplicate_header(self):
+        url = reverse("core:upload_employees")
+
+        duplicate_header = "اسم الكفيل.1"
+        file = self._excel_file(
+            [{"employee_number": "5", "name": "Fadi", duplicate_header: "Kaf"}]
+        )
+
+        self.client.post(
+            url,
+            {"report_date": "2024-01-01", "is_haramain": "false", "file": file},
+        )
+
+        emp = RecruitmentEmployee.objects.get(employee_number="5")
+        self.assertEqual(emp.sponsor_name, "Kaf")

--- a/core/views.py
+++ b/core/views.py
@@ -111,6 +111,7 @@ def _clean_header(name: str) -> str:
         name = name.replace(ch, "")
     name = name.strip()
     name = re.sub(r"[:\u0589\u061b]+$", "", name).strip()
+    name = re.sub(r"\.\d+$", "", name)
     return name
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- normalize Excel headers with duplicate suffixes
- test that sponsor column imports even when Excel adds a numeric suffix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fc033650883329523c2b088c2e339