### PR TITLE
Fix header cleaning for Excel imports

### DIFF
--- a/core/management/commands/import_legacy_excel.py
+++ b/core/management/commands/import_legacy_excel.py
@@ -67,6 +67,7 @@ def clean_name(name: str) -> str:
         name = name.replace(ch, '')
     name = name.strip()
     name = re.sub(r'[:\u0589\u061b]+$', '', name).strip()
+    name = re.sub(r'\.\d+$', '', name)
     return name
 
 

--- a/import_employees.py
+++ b/import_employees.py
@@ -70,6 +70,7 @@ def clean_header(name: str) -> str:
         name = name.replace(ch, '')
     name = name.strip()
     name = re.sub(r'[:\u0589\u061b]+$', '', name).strip()
+    name = re.sub(r'\.\d+$', '', name)
     return name
 
 

--- a/import_legacy.py
+++ b/import_legacy.py
@@ -67,6 +67,7 @@ def clean_name(name: str) -> str:
         name = name.replace(ch, '')
     name = name.strip()
     name = re.sub(r'[:\u0589\u061b]+$', '', name).strip()
+    name = re.sub(r'\.\d+$', '', name)
     return name
 
 


### PR DESCRIPTION
## Summary
- strip numeric suffixes like `.1` when cleaning Excel headers
- make the change in all import scripts

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686fc271a0388332be42683506480267