### PR TITLE
Fix sponsor column import handling

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -271,7 +271,15 @@ def other_services(request):
 
 def _extract_employee_data(row: dict) -> dict:
     """Return cleaned values from a raw Excel row."""
-    cleaned = {_clean_header(k): v for k, v in row.items()}
+    cleaned: dict[str, object] = {}
+    for k, v in row.items():
+        name = _clean_header(k)
+        if name in cleaned:
+            current = cleaned[name]
+            if (current in ("", None)) and (v not in ("", None)):
+                cleaned[name] = v
+        else:
+            cleaned[name] = v
     data: dict[str, object] = {}
     for field, aliases in EMPLOYEE_COLUMN_MAP.items():
         for a in aliases:

--- a/import_employees.py
+++ b/import_employees.py
@@ -116,10 +116,18 @@ def fill_missing_columns(df: pd.DataFrame) -> pd.DataFrame:
 def import_rows(df: pd.DataFrame) -> int:
     count = 0
     for idx, row in df.iterrows():
+        cleaned: dict[str, object] = {}
+        for col, val in row.items():
+            if col in cleaned:
+                if (cleaned[col] in ("", None)) and (val not in ("", None)):
+                    cleaned[col] = val
+            else:
+                cleaned[col] = val
+
         data = {}
         for col, model_field in FIELD_MAP.items():
-            if col in row:
-                data[model_field] = row[col]
+            if col in cleaned and cleaned[col] not in ("", None):
+                data[model_field] = cleaned[col]
 
         # handle decimal conversion
         if data.get('evaluation') not in (None, ''):


### PR DESCRIPTION
## Summary
- improve `_extract_employee_data` to ignore empty duplicate columns and use the non-empty value
- apply the same duplicate-handling logic in the standalone `import_employees.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fc445283c83328eca5befbc403715