### PR TITLE
Preserve sponsor column when importing legacy records

### DIFF
--- a/core/management/commands/import_legacy_excel.py
+++ b/core/management/commands/import_legacy_excel.py
@@ -84,6 +84,8 @@ class Command(BaseCommand):
         df.columns = [clean_name(c) for c in df.columns]
         df.rename(columns=COLUMN_MAP, inplace=True)
 
+        sponsor_indices = [i for i, col in enumerate(df.columns) if col == "sponsor"]
+
         # Clean textual result values and convert evaluation to numeric when possible
         if 'result' in df.columns:
             df['result'] = df['result'].fillna('').apply(clean_name)
@@ -95,9 +97,23 @@ class Command(BaseCommand):
                         if f.concrete and not f.auto_created}
 
         records = []
-        for row in df.to_dict(orient='records'):
-            cleaned = {f: (None if pd.isna(row.get(f)) else row.get(f)) for f in model_fields}
-            # Skip completely empty rows
+        for _, row in df.iterrows():
+            cleaned = {}
+            for f in model_fields:
+                if f == "sponsor":
+                    continue
+                val = row.get(f)
+                cleaned[f] = None if pd.isna(val) else val
+
+            sponsor_value = None
+            for idx in sponsor_indices:
+                if idx < len(row):
+                    val = row.iloc[idx]
+                    if val not in ("", None) and not (isinstance(val, float) and pd.isna(val)):
+                        sponsor_value = val
+                        break
+            cleaned["sponsor"] = sponsor_value
+
             if all(value is None for value in cleaned.values()):
                 continue
             records.append(LegacyRecruitmentRecord(**cleaned))

--- a/core/views.py
+++ b/core/views.py
@@ -456,9 +456,20 @@ def import_report_records(request, pk):
     df.columns = [_clean_header(c) for c in df.columns]
     df.rename(columns=LEGACY_COLUMN_MAP, inplace=True)
 
+    sponsor_indices = [i for i, col in enumerate(df.columns) if col == "sponsor"]
+
     added = 0
     for _, row in df.iterrows():
         emp_id = str(row.get("emp_id", "")).strip()
+
+        sponsor_value = None
+        for idx in sponsor_indices:
+            if idx < len(row):
+                val = row.iloc[idx]
+                if val not in ("", None) and not (isinstance(val, float) and pd.isna(val)):
+                    sponsor_value = val
+                    break
+
         LegacyRecruitmentRecord.objects.create(
             employees=emp_id,
             emp_id=emp_id,
@@ -467,7 +478,7 @@ def import_report_records(request, pk):
             passport_no=(str(row.get("passport_no", "")).strip() or None),
             nationality=(str(row.get("nationality", "")).strip() or None),
             profession=(str(row.get("profession", "")).strip() or None),
-            sponsor=(str(row.get("sponsor", "")).strip() or None),
+            sponsor=(str(sponsor_value).strip() if sponsor_value not in (None, "") else None),
         )
         added += 1
 

--- a/import_legacy.py
+++ b/import_legacy.py
@@ -81,6 +81,8 @@ def main():
     # Rename columns to match model field names
     df.rename(columns=COLUMN_MAP, inplace=True)
 
+    sponsor_indices = [i for i, col in enumerate(df.columns) if col == "sponsor"]
+
     # Clean textual result values but keep all rows
     if 'result' in df.columns:
         df['result'] = df['result'].fillna('').apply(clean_name)
@@ -97,11 +99,23 @@ def main():
     }
 
     records = []
-    for row in df.to_dict(orient='records'):
-        cleaned = {
-            f: (None if pd.isna(row.get(f)) else row.get(f))
-            for f in model_fields
-        }
+    for _, row in df.iterrows():
+        cleaned = {}
+        for f in model_fields:
+            if f == "sponsor":
+                continue
+            val = row.get(f)
+            cleaned[f] = None if pd.isna(val) else val
+
+        sponsor_value = None
+        for idx in sponsor_indices:
+            if idx < len(row):
+                val = row.iloc[idx]
+                if val not in ("", None) and not (isinstance(val, float) and pd.isna(val)):
+                    sponsor_value = val
+                    break
+        cleaned["sponsor"] = sponsor_value
+
         if all(value is None for value in cleaned.values()):
             continue
         records.append(LegacyRecruitmentRecord(**cleaned))


### PR DESCRIPTION
## Summary
- keep duplicate `sponsor` columns when importing
- look up the first non-empty `sponsor` value for `LegacyRecruitmentRecord`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fc700c61c8332b68c484914412c6e