### PR TITLE
Fix header cleaning in import command

### DIFF
--- a/core/management/commands/import_exact_excel.py
+++ b/core/management/commands/import_exact_excel.py
@@ -1,6 +1,37 @@
 from django.core.management.base import BaseCommand
 from core.models import LegacyRecruitmentRecord
 import pandas as pd
+import re
+
+# Some Excel editors include invisible characters in the column headers. If we
+# don't strip them, the names won't match the model field names and values will
+# be lost. This helper mimics the cleaning logic used in other import scripts.
+INVISIBLE_CHARS = {
+    "\u200f",  # RTL mark
+    "\ufeff",  # BOM
+}
+
+# Minimal column mapping for known sponsor aliases
+COLUMN_MAP = {
+    "Sponsor": "sponsor",
+    "Sponsor Name": "sponsor",
+    "Spensor": "sponsor",
+    "Spensor Name": "sponsor",
+    "اسبنسور": "sponsor",
+    "الاسبنسور": "sponsor",
+    "سبونسر": "sponsor",
+    "السبونسر": "sponsor",
+}
+
+
+def clean_name(name: str) -> str:
+    name = str(name)
+    for ch in INVISIBLE_CHARS:
+        name = name.replace(ch, "")
+    name = name.strip()
+    name = re.sub(r"[:\u0589\u061b]+$", "", name).strip()
+    name = re.sub(r"\.\d+$", "", name)
+    return name
 
 
 class Command(BaseCommand):
@@ -12,6 +43,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         path = options["excel_file"]
         df = pd.read_excel(path)
+        df.columns = [clean_name(c) for c in df.columns]
+        df.rename(columns=COLUMN_MAP, inplace=True)
 
         model_fields = {
             f.name
@@ -24,8 +57,6 @@ class Command(BaseCommand):
             if row.isna().all():
                 continue
             data = row.to_dict()
-            if "Sponsor" in data and "sponsor" not in data:
-                data["sponsor"] = data["Sponsor"]
             cleaned = {k: v for k, v in data.items() if k in model_fields}
             LegacyRecruitmentRecord.objects.create(**cleaned)
             count += 1

--- a/core/tests.py
+++ b/core/tests.py
@@ -376,6 +376,7 @@ class UploadEmployeesHeaderCleaningTest(TestCase):
 
         emp = RecruitmentEmployee.objects.get(employee_number="1")
         self.assertEqual(emp.sponsor_name, "Kafil")
+
     def test_import_sponsor_with_colon_header(self):
         url = reverse("core:upload_employees")
 
@@ -439,3 +440,32 @@ class UploadEmployeesHeaderCleaningTest(TestCase):
 
         emp = RecruitmentEmployee.objects.get(employee_number="5")
         self.assertEqual(emp.sponsor_name, "Kaf")
+
+
+class ImportExactExcelCommandTest(TestCase):
+    """Ensure direct import command cleans headers properly."""
+
+    def test_clean_headers_import(self):
+        from django.core.management import call_command
+        import tempfile
+
+        buf = io.BytesIO()
+        pd.DataFrame(
+            [
+                {
+                    "\u200fEmployees": "X",
+                    "Emp. ID": "10",
+                    "Nationality": "SA",
+                }
+            ]
+        ).to_excel(buf, index=False)
+        buf.seek(0)
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as tmp:
+            tmp.write(buf.getvalue())
+            tmp.flush()
+            call_command("import_exact_excel", tmp.name)
+
+        rec = LegacyRecruitmentRecord.objects.get(emp_id="10")
+        self.assertEqual(rec.employees, "X")
+        self.assertEqual(rec.nationality, "SA")


### PR DESCRIPTION
## Summary
- clean header names and sponsor aliases in `import_exact_excel` command
- add a regression test for the command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ff91ebefc8332809ca234769b13f4