### PR TITLE
Fix remove debug print

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -748,7 +748,6 @@ def update_database(request):
         qs = LegacyRecruitmentRecord.objects.all()
         data = list(qs.values(*field_map.keys()))
         df = pd.DataFrame.from_records(data, columns=field_map.keys())
-        print(df[["emp_id", "sponsor"]].head(20))
 
         # Remove completely empty rows before exporting
         df = df.dropna(how="all")


### PR DESCRIPTION
## Summary
- drop leftover print statement from database export view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686ffce860c88332b6bf9a853b148d0a