### PR TITLE
Add missing fill_legacy_records command

### DIFF
--- a/core/management/commands/fill_legacy_records.py
+++ b/core/management/commands/fill_legacy_records.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+from core.models import RecruitmentEmployee, LegacyRecruitmentRecord
+
+
+class Command(BaseCommand):
+    help = "يستكمل الحقول الفارغة في LegacyRecruitmentRecord من RecruitmentEmployee"
+
+    def handle(self, *args, **options):
+        qs = LegacyRecruitmentRecord.objects.filter(name_ar__isnull=True)
+        updated = 0
+
+        for rec in qs:
+            try:
+                src = RecruitmentEmployee.objects.get(employee_number=rec.employee_number)
+            except RecruitmentEmployee.DoesNotExist:
+                continue
+
+            rec.name_ar = src.name
+            rec.name_en = src.name_en
+            rec.nationality = src.nationality
+            rec.profession = src.official_job
+            rec.sponsor = src.sponsor_name
+            rec.save()
+            updated += 1
+
+        self.stdout.write(self.style.SUCCESS(f"✅ تم تحديث {updated} سجلًّا."))


### PR DESCRIPTION
## Summary
- implement `fill_legacy_records` management command to copy missing
  fields from `RecruitmentEmployee` into `LegacyRecruitmentRecord`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.2.2)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687008a22ab08332a82e709ec47dc058