### PR TITLE
Handle oversized legacy records

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -306,3 +306,12 @@ class LegacyRecruitmentRecord(models.Model):
     def __str__(self) -> str:
         return f"{self.emp_id} - {self.name_ar or self.name_en}".strip()
 
+    def save(self, *args, **kwargs):
+        """Truncate overly long CharField values before saving."""
+        for field in self._meta.get_fields():
+            if isinstance(field, models.CharField) and not field.auto_created:
+                val = getattr(self, field.name)
+                if isinstance(val, str) and field.max_length and len(val) > field.max_length:
+                    setattr(self, field.name, val[: field.max_length])
+        super().save(*args, **kwargs)
+

--- a/core/tests.py
+++ b/core/tests.py
@@ -217,6 +217,26 @@ class ImportReportRecordsTest(TestCase):
         self.assertEqual(rec.profession, "Engineer")
         self.assertEqual(rec.sponsor, "XYZ")
 
+    def test_import_truncates_long_values(self):
+        long_id = "E" * 60
+        long_nat = "N" * 60
+        report = RecruitmentReport.objects.create(
+            filename="long.xlsx",
+            report_date=datetime.date(2024, 4, 1),
+            file_size=1,
+            is_haramain=False,
+            columns=["EMP NO", "Nationality"],
+            rows=[{"EMP NO": long_id, "Nationality": long_nat}],
+        )
+
+        self.client.force_login(self.user)
+        url = reverse("core:import_report_records", args=[report.pk])
+        self.client.post(url)
+
+        rec = LegacyRecruitmentRecord.objects.first()
+        self.assertEqual(rec.emp_id, long_id[:50])
+        self.assertEqual(rec.nationality, long_nat[:50])
+
 
 class UploadEmployeesUpdateTest(TestCase):
     """التأكد من تحديث السجلات الموجودة بدلاً من تكرارها."""


### PR DESCRIPTION
## Summary
- protect `LegacyRecruitmentRecord.save()` from values exceeding `max_length`
- test that long values in imported reports are truncated

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687011000b84833285ace77cb5daa1b2