### PR TITLE
Improve legacy import handling

### DIFF
--- a/core/management/commands/fill_legacy_records.py
+++ b/core/management/commands/fill_legacy_records.py
@@ -3,24 +3,37 @@ from core.models import RecruitmentEmployee, LegacyRecruitmentRecord
 
 
 class Command(BaseCommand):
-    help = "يستكمل الحقول الفارغة في LegacyRecruitmentRecord من RecruitmentEmployee"
+    help = "Fill missing fields in LegacyRecruitmentRecord from RecruitmentEmployee"
 
     def handle(self, *args, **options):
-        qs = LegacyRecruitmentRecord.objects.filter(name_ar__isnull=True)
         updated = 0
 
-        for rec in qs:
+        for rec in LegacyRecruitmentRecord.objects.all().iterator():
             try:
-                src = RecruitmentEmployee.objects.get(employee_number=rec.employee_number)
+                src = RecruitmentEmployee.objects.get(employee_number=rec.emp_id)
             except RecruitmentEmployee.DoesNotExist:
                 continue
 
-            rec.name_ar = src.name
-            rec.name_en = src.name_en
-            rec.nationality = src.nationality
-            rec.profession = src.official_job
-            rec.sponsor = src.sponsor_name
-            rec.save()
-            updated += 1
+            changed = False
 
-        self.stdout.write(self.style.SUCCESS(f"✅ تم تحديث {updated} سجلًّا."))
+            if not rec.name_ar and src.name:
+                rec.name_ar = src.name
+                changed = True
+            if not rec.name_en and src.name_en:
+                rec.name_en = src.name_en
+                changed = True
+            if not rec.nationality and src.nationality:
+                rec.nationality = src.nationality
+                changed = True
+            if not rec.profession and src.official_job:
+                rec.profession = src.official_job
+                changed = True
+            if not rec.sponsor and src.sponsor_name:
+                rec.sponsor = src.sponsor_name
+                changed = True
+
+            if changed:
+                rec.save()
+                updated += 1
+
+        self.stdout.write(self.style.SUCCESS(f"✅ تم تحديث {updated} سجلًا."))

--- a/core/management/commands/import_exact_excel.py
+++ b/core/management/commands/import_exact_excel.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 from core.models import LegacyRecruitmentRecord
+from django.db import models
 import pandas as pd
 import re
 
@@ -73,6 +74,14 @@ def clean_name(name: str) -> str:
     return name
 
 
+def truncate_record(rec: LegacyRecruitmentRecord) -> None:
+    for field in rec._meta.get_fields():
+        if isinstance(field, models.CharField):
+            val = getattr(rec, field.name)
+            if isinstance(val, str) and field.max_length and len(val) > field.max_length:
+                setattr(rec, field.name, val[: field.max_length])
+
+
 class Command(BaseCommand):
     help = "Import LegacyRecruitmentRecord rows from an Excel file when column names match model fields."
 
@@ -119,7 +128,9 @@ class Command(BaseCommand):
 
             if all(value is None for value in cleaned.values()):
                 continue
-            records.append(LegacyRecruitmentRecord(**cleaned))
+            rec = LegacyRecruitmentRecord(**cleaned)
+            truncate_record(rec)
+            records.append(rec)
 
         if records:
             LegacyRecruitmentRecord.objects.bulk_create(records)

--- a/core/management/commands/import_legacy_excel.py
+++ b/core/management/commands/import_legacy_excel.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 from core.models import LegacyRecruitmentRecord
+from django.db import models
 import pandas as pd
 import re
 
@@ -71,6 +72,14 @@ def clean_name(name: str) -> str:
     return name
 
 
+def truncate_record(rec: LegacyRecruitmentRecord) -> None:
+    for field in rec._meta.get_fields():
+        if isinstance(field, models.CharField):
+            val = getattr(rec, field.name)
+            if isinstance(val, str) and field.max_length and len(val) > field.max_length:
+                setattr(rec, field.name, val[: field.max_length])
+
+
 class Command(BaseCommand):
     help = 'Import legacy recruitment records from an Excel file.'
 
@@ -116,7 +125,9 @@ class Command(BaseCommand):
 
             if all(value is None for value in cleaned.values()):
                 continue
-            records.append(LegacyRecruitmentRecord(**cleaned))
+            rec = LegacyRecruitmentRecord(**cleaned)
+            truncate_record(rec)
+            records.append(rec)
 
         if records:
             LegacyRecruitmentRecord.objects.bulk_create(records)

--- a/core/views.py
+++ b/core/views.py
@@ -95,6 +95,7 @@ LEGACY_COLUMN_MAP = {
     "Employees": "emp_id",
     "emp.id": "emp_id",
     "Name Arabic": "name_ar",
+    "Name": "name_ar",
     "name.(arabic)": "name_ar",
     "Name English": "name_en",
     "name.(english)": "name_en",
@@ -494,6 +495,10 @@ def import_report_records(request, pk):
         name_ar = (row.get("name_ar") or row.get("name") or "").strip() or None
         name_en = (row.get("name_en") or "").strip() or None
         profession = (row.get("profession") or row.get("official_job") or "").strip() or None
+
+        if not name_ar and not name_en:
+            # Skip completely blank rows
+            continue
 
         missing = [k for k in ["name_ar", "name_en", "profession"] if not row.get(k)]
         if missing:

--- a/import_legacy.py
+++ b/import_legacy.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from django.db import models
 from core.models import LegacyRecruitmentRecord
 
 # Path to the Excel file to import. Adjust this before running.
@@ -71,6 +72,14 @@ def clean_name(name: str) -> str:
     return name
 
 
+def truncate_record(rec: LegacyRecruitmentRecord) -> None:
+    for field in rec._meta.get_fields():
+        if isinstance(field, models.CharField):
+            val = getattr(rec, field.name)
+            if isinstance(val, str) and field.max_length and len(val) > field.max_length:
+                setattr(rec, field.name, val[: field.max_length])
+
+
 def main():
     # Load the Excel file
     df = pd.read_excel(EXCEL_FILE)
@@ -118,7 +127,9 @@ def main():
 
         if all(value is None for value in cleaned.values()):
             continue
-        records.append(LegacyRecruitmentRecord(**cleaned))
+        rec = LegacyRecruitmentRecord(**cleaned)
+        truncate_record(rec)
+        records.append(rec)
 
     if records:
         LegacyRecruitmentRecord.objects.bulk_create(records)


### PR DESCRIPTION
## Summary
- map generic "Name" column to `name_ar`
- skip importing blank rows
- ensure missing fields are populated with a command
- truncate long values before bulk import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687012a068e483328f9a0cb7929bcf95