### PR TITLE
Fix duplicate legacy import

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -167,14 +167,14 @@ class ImportReportRecordsTest(TestCase):
             ],
         )
 
-    def test_import_allows_duplicates(self):
+    def test_import_skips_duplicates(self):
         self.client.force_login(self.user)
         url = reverse("core:import_report_records", args=[self.report.pk])
         self.client.post(url)
         self.assertEqual(LegacyRecruitmentRecord.objects.count(), 1)
-        # Second call should create a duplicate record
+        # Second call should not create a duplicate record
         self.client.post(url)
-        self.assertEqual(LegacyRecruitmentRecord.objects.count(), 2)
+        self.assertEqual(LegacyRecruitmentRecord.objects.count(), 1)
 
     def test_import_arabic_headers(self):
         """Ensure Arabic column names are mapped correctly."""

--- a/core/views.py
+++ b/core/views.py
@@ -480,9 +480,15 @@ def import_report_records(request, pk):
 
     sponsor_indices = [i for i, col in enumerate(df.columns) if col == "sponsor"]
 
+    existing_ids = set(
+        LegacyRecruitmentRecord.objects.values_list("emp_id", flat=True)
+    )
     added = 0
     for _, row in df.iterrows():
         emp_id = str(row.get("emp_id", "")).strip()
+        if not emp_id or emp_id in existing_ids:
+            continue
+        existing_ids.add(emp_id)
 
         sponsor_value = None
         for idx in sponsor_indices:


### PR DESCRIPTION
## Summary
- avoid inserting duplicate `LegacyRecruitmentRecord` rows
- update test to check duplicates are skipped

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6870f4d3d96483328f095350039b48f5