### PR TITLE
Remove Learner model from admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,20 +1,9 @@
 # core/admin.py
 from django.contrib import admin
 
-from .models import Learner
-
-
-@admin.register(Learner)
-class LearnerAdmin(admin.ModelAdmin):
-    list_display = ("first_name_ar", "last_name_ar", "date_created")
-    search_fields = (
-        "first_name_ar",
-        "last_name_ar",
-        "first_name_en",
-        "last_name_en",
-    )
-
-
+# The Learner model is intentionally not registered with the Django admin
+# interface. Administrators manage trainees through custom views instead of
+# using the default admin site.
 # The following models were previously registered with the admin site but have
 # been removed as they are no longer managed through the Django admin
 # interface:
@@ -26,4 +15,3 @@ class LearnerAdmin(admin.ModelAdmin):
 # - EmployeeEvaluation
 # - RecruitmentReport
 # - LegacyRecruitmentRecord
-


### PR DESCRIPTION
## Summary
- stop registering the `Learner` model with the Django admin

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6871af11d77083328d1b2fd6fc3fadab