### PR TITLE
Add legacy employee sheet upload section

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -163,6 +163,17 @@ class RecruitmentReportForm(forms.Form):
     )
 
 
+class LegacyUploadForm(forms.Form):
+    """Upload legacy employee spreadsheets."""
+
+    file = MultipleFileField(
+        label="كشف الموظفين (Excel)",
+        widget=ClearableMultipleFileInput(
+            attrs={"class": "w-full border border-gray-300 rounded-md p-2"}
+        ),
+    )
+
+
 class RecruitmentReportEditForm(forms.ModelForm):
     class Meta:
         model = RecruitmentReport

--- a/core/urls.py
+++ b/core/urls.py
@@ -61,6 +61,11 @@ urlpatterns = [
 
     # استقدام الحديث
     path("recruitment/upload/", views.upload_employees, name="upload_employees"),
+    path(
+        "recruitment/upload-legacy/",
+        views.upload_legacy_records,
+        name="upload_legacy_records",
+    ),
     path("recruitment/report/<int:pk>/", views.report_detail, name="report_detail"),
     path("recruitment/report/<int:pk>/delete/", views.delete_report, name="delete_report"),
     path("recruitment/report/<int:pk>/edit/", views.edit_report, name="edit_report"),

--- a/core/views.py
+++ b/core/views.py
@@ -444,6 +444,70 @@ def upload_employees(request):
         "search": search,
     })
 
+
+def upload_legacy_records(request):
+    """Upload legacy employee spreadsheets to LegacyRecruitmentRecord."""
+
+    if request.method == "POST":
+        form = LegacyUploadForm(request.POST, request.FILES)
+        if not form.is_valid():
+            messages.error(request, form.errors.as_text())
+            return redirect("core:upload_legacy_records")
+
+        existing_ids = set(
+            LegacyRecruitmentRecord.objects.values_list("emp_id", flat=True)
+        )
+        added_total = 0
+
+        for excel in request.FILES.getlist("file"):
+            try:
+                df = pd.read_excel(excel)
+            except Exception as exc:
+                logger.exception("Failed reading %s", excel.name)
+                messages.error(request, f"{excel.name}: {exc}")
+                continue
+
+            df.columns = [_clean_header(c) for c in df.columns]
+            df.rename(columns=LEGACY_COLUMN_MAP, inplace=True)
+
+            sponsor_indices = [i for i, c in enumerate(df.columns) if c == "sponsor"]
+
+            for _, row in df.iterrows():
+                emp_id = clean_emp_id(row.get("emp_id", ""))
+                if not emp_id or emp_id in existing_ids:
+                    continue
+                existing_ids.add(emp_id)
+
+                sponsor_value = None
+                for idx in sponsor_indices:
+                    if idx < len(row):
+                        val = row.iloc[idx]
+                        if val not in ("", None) and not (isinstance(val, float) and pd.isna(val)):
+                            sponsor_value = val
+                            break
+
+                LegacyRecruitmentRecord.objects.create(
+                    employees=str(row.get("employees", "")).strip() or None,
+                    emp_id=emp_id,
+                    name_ar=(str(row.get("name_ar", "")).strip() or None),
+                    name_en=(str(row.get("name_en", "")).strip() or None),
+                    passport_no=(str(row.get("passport_no", "")).strip() or None),
+                    nationality=(str(row.get("nationality", "")).strip() or None),
+                    profession=(str(row.get("profession", "")).strip() or None),
+                    sponsor=(str(sponsor_value).strip() if sponsor_value not in (None, "") else None),
+                )
+                added_total += 1
+
+        if added_total:
+            messages.success(request, f"تمت إضافة {added_total} سجلًا بنجاح")
+        else:
+            messages.info(request, "لا توجد سجلات مضافة")
+        return redirect("core:upload_legacy_records")
+
+    form = LegacyUploadForm()
+    records = LegacyRecruitmentRecord.objects.order_by("-id")[:50]
+    return render(request, "core/upload_legacy_records.html", {"form": form, "records": records})
+
 # ------------------------------------------------------------------------------
 # مشاهد التقارير / الموظفين
 # ------------------------------------------------------------------------------

--- a/templates/core/recruitment_dashboard.html
+++ b/templates/core/recruitment_dashboard.html
@@ -17,6 +17,10 @@
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-users"></i></div></div>
       <div class="recruitment-name">رفع كشف الموظفين</div>
     </a>
+    <a href="{% url 'core:upload_legacy_records' %}" class="recruitment-card" title="رفع كشوفات الموظفين">
+      <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-file-upload"></i></div></div>
+      <div class="recruitment-name">رفع كشوفات الموظفين</div>
+    </a>
     <a href="{% url 'core:recruitment_step' 'forms' %}" class="recruitment-card" title="إصدار نماذج التقييم">
       <div class="icon-wrap"><div class="recruitment-icon"><i class="fas fa-file-alt"></i></div></div>
       <div class="recruitment-name">إصدار نماذج التقييم</div>

--- a/templates/core/upload_legacy_records.html
+++ b/templates/core/upload_legacy_records.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block title %}رفع كشوفات الموظفين{% endblock %}
+{% block content %}
+<h1 class="text-3xl font-bold mb-6 text-center text-[#119383]">رفع كشوفات الموظفين</h1>
+<div class="max-w-xl mx-auto bg-white p-6 rounded-xl shadow">
+  <form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    <div>
+      <label class="block mb-1 text-sm text-gray-600">{{ form.file.label }}</label>
+      {{ form.file }}
+      {{ form.file.errors }}
+    </div>
+    <button type="submit" class="w-full py-2 bg-green-600 hover:bg-green-700 text-white rounded">رفع</button>
+  </form>
+</div>
+{% if records %}
+  <h2 class="text-xl font-bold mt-8 mb-4 text-center">أحدث السجلات</h2>
+  <div class="overflow-x-auto bg-white rounded shadow mx-auto max-w-3xl">
+    <table class="min-w-full text-sm text-center">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-2 py-1">Emp. ID</th>
+          <th class="px-2 py-1">Name (Arabic)</th>
+          <th class="px-2 py-1">Nationality</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in records %}
+        <tr class="odd:bg-gray-50">
+          <td class="px-2 py-1">{{ r.emp_id }}</td>
+          <td class="px-2 py-1">{{ r.name_ar|default:r.name_en }}</td>
+          <td class="px-2 py-1">{{ r.nationality }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `LegacyUploadForm` for legacy employee spreadsheets
- enable uploading legacy employee records via `upload_legacy_records` view
- add route and dashboard link for the new section
- provide a basic upload template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6871b385bfcc83329bf2a0a7b2eb226b