### PR TITLE
Fix employee upload for 'Employees' header

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -48,6 +48,7 @@ EMPLOYEE_COLUMN_MAP: dict[str, list[str]] = {
     "employee_number": [
         "employee_number",
         "الرقم الوظيفي",
+        "Employees",
         "Emp. ID",
         "Emp ID",
         "EMP ID",


### PR DESCRIPTION
## Summary
- adjust `EMPLOYEE_COLUMN_MAP` to recognize `Employees` header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687366d96ce88332b0b481097206ff5f