### PR TITLE
Fix column renaming with custom pandas

### DIFF
--- a/pandas.py
+++ b/pandas.py
@@ -116,6 +116,21 @@ class DataFrame:
     def columns(self):
         return self._columns
 
+    @columns.setter
+    def columns(self, new_columns):
+        old_columns = self._columns
+        if len(new_columns) != len(old_columns):
+            raise ValueError("Column length mismatch")
+        new_columns = list(new_columns)
+        self._records = [
+            {
+                new_col: row.get(old_col)
+                for old_col, new_col in zip(old_columns, new_columns)
+            }
+            for row in self._records
+        ]
+        self._columns = new_columns
+
     def __len__(self):
         return len(self._records)
 


### PR DESCRIPTION
## Summary
- implement a setter for `DataFrame.columns`

The existing minimal pandas implementation lacked a setter for the `columns` property. This caused an `AttributeError` when views tried to rename DataFrame columns.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68736c6812b88332825fa84e91617b3e